### PR TITLE
Keep alive workflow

### DIFF
--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -20,10 +20,10 @@ runs:
       run: |
         WORKFLOW_ID=""
         WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows"
-        if [[ ${{ inputs.workflow }} == .github/* ]]; then
+        if [[ "${{ inputs.workflow }}" == .github/* ]]; then
           echo "[INFO] Using filepath to find workflow ID: ${{ inputs.workflow }}"
           WORKFLOW_FILE=$(echo "${{ inputs.workflow }}" | awk -F '/' '{print $NF}')
-          curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_FILE"
+          WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_FILE" | jq -r .id)
         else
           echo "[INFO] Using workflow name to find workflow ID: ${{ inputs.workflow }}"
           curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT"

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -24,10 +24,10 @@ runs:
         if [[ "${{ inputs.workflow }}" == .github/* ]]; then
           echo "[INFO] Using filepath to find workflow ID: ${{ inputs.workflow }}"
           WORKFLOW_FILE=$(echo "${{ inputs.workflow }}" | awk -F '/' '{print $NF}')
-          WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_FILE" | jq -r .id)
+          WORKFLOW_ID=$(curl -sf -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_FILE" | jq -r .id)
         else
           echo "[INFO] Using workflow name to find workflow ID: ${{ inputs.workflow }}"
-          WORKFLOWS=$(curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT")
+          WORKFLOWS=$(curl -sf -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT")
           for wf in $(echo "${WORKFLOWS}" | jq -c -r '.workflows[] | @base64'); do
             WF_NAME=$(echo "$wf" | base64 --decode | jq -r .name)
             if [[ "$WF_NAME" == "${{ inputs.workflow }}" ]]; then
@@ -37,6 +37,6 @@ runs:
         fi
 
         echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID $WORKFLOW_ID"
-        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/disable"
-        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/enable"
+        curl -fX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/disable"
+        curl -fX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/enable"
       shell: bash

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -5,8 +5,9 @@ inputs:
     description: 'The repository the workflow is in'
     default: ${{ github.repository }}
     required: true
-  workflow_id:
-    description: 'A single Workflow ID'
+  workflow:
+    description: 'A path to a workflow file in a repository, or the name string of a workflow'
+    default: ${{ github.workflow }}
     required: true
   access_token:
     description: 'Your GitHub Access Token, defaults to: {{ github.token }}'
@@ -17,8 +18,8 @@ runs:
   steps:
     - name: Flip workflow
       run: |
-        echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID ${{ inputs.workflow_id }}"
-        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}"
+        echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID ${{ inputs.workflow }}"
+        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow }}"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/disable"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/enable"
       shell: sh

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -1,6 +1,9 @@
 name: "Keep workflow enabled"
-description: "Disables and re-enables the running workflow"
+description: "Disables and re-enables the running workflow to avoid 60 day CI disables from GitHub for repo inactivity"
 inputs:
+  repository:
+    description: 'The repository the workflow is in'
+    required: true
   workflow_id:
     description: 'A single Workflow ID'
     required: true
@@ -16,7 +19,7 @@ runs:
       shell: sh
     - name: Flip workflow
       run: |
-        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" ${WORKFLOW_API_ENDPOINT}/${GITHUB_ACTION}/disable
-        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" ${WORKFLOW_API_ENDPOINT}/${GITHUB_ACTION}/enable
+        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/disable
+        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/enable
       shell: sh
 

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -17,9 +17,8 @@ runs:
   steps:
     - name: Flip workflow
       run: |
-        echo "[INFO] Flipping workflow for ${{ github.repository }} workflow ID ${GITHUB_ACTION}"
         echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID ${{ inputs.workflow_id }}"
-        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ github.repository }}/actions/workflows/${GITHUB_ACTION}"
-        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/disable"
-        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/enable"
+        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}"
+        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/disable"
+        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/enable"
       shell: sh

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -18,8 +18,19 @@ runs:
   steps:
     - name: Flip workflow
       run: |
-        echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID ${{ inputs.workflow }}"
-        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow }}"
-        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/disable"
-        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/enable"
+        export WORKFLOW_ID
+        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows
+
+        if [[ ${{ inputs.workflow }} == .github/* ]]; then
+          echo "[INFO] Using filepath to find workflow ID: ${{ inputs.workflow }}"
+          WORKFLOW_FILE=$(awk -F'/' '{print $NF}' <<< "${{ inputs.workflow }}")
+          curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_FILE"
+        else
+          echo "[INFO] Using workflow name to find workflow ID: ${{ inputs.workflow }}"
+          curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT"
+        fi
+
+        echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID $WORKFLOW_ID"
+        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/disable"
+        curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/enable"
       shell: sh

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -14,12 +14,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install dependencies
-      run: apt update && apt install jq -y
-      shell: sh
     - name: Flip workflow
       run: |
-        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/disable
-        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/enable
+        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/disable
+        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/enable
       shell: sh
 

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Flip workflow
       run: |
         WORKFLOW_ID=""
-        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows
+        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows"
         if [[ ${{ inputs.workflow }} == .github/* ]]; then
           echo "[INFO] Using filepath to find workflow ID: ${{ inputs.workflow }}"
           WORKFLOW_FILE=$(awk -F'/' '{print $NF}' <<< "${{ inputs.workflow }}")

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -18,9 +18,8 @@ runs:
   steps:
     - name: Flip workflow
       run: |
-        export WORKFLOW_ID=""
+        WORKFLOW_ID=""
         WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows
-
         if [[ ${{ inputs.workflow }} == .github/* ]]; then
           echo "[INFO] Using filepath to find workflow ID: ${{ inputs.workflow }}"
           WORKFLOW_FILE=$(awk -F'/' '{print $NF}' <<< "${{ inputs.workflow }}")
@@ -29,7 +28,6 @@ runs:
           echo "[INFO] Using workflow name to find workflow ID: ${{ inputs.workflow }}"
           curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT"
         fi
-
         echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID $WORKFLOW_ID"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/disable"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/enable"

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -1,0 +1,22 @@
+name: "Keep workflow enabled"
+description: "Disables and re-enables the running workflow"
+inputs:
+  workflow_id:
+    description: 'A single Workflow ID'
+    required: true
+  access_token:
+    description: 'Your GitHub Access Token, defaults to: {{ github.token }}'
+    default: '${{ github.token }}'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: apt update && apt install jq -y
+      shell: sh
+    - name: Flip workflow
+      run: |
+        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" ${WORKFLOW_API_ENDPOINT}/${GITHUB_ACTION}/disable
+        curl -X PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" ${WORKFLOW_API_ENDPOINT}/${GITHUB_ACTION}/enable
+      shell: sh
+

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -16,6 +16,7 @@ runs:
   steps:
     - name: Flip workflow
       run: |
+        echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID ${{ inputs.workflow_id }}"
         curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/disable
         curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/enable
       shell: sh

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -7,7 +7,6 @@ inputs:
     required: true
   workflow_id:
     description: 'A single Workflow ID'
-    default: ${{ github.action }}
     required: true
   access_token:
     description: 'Your GitHub Access Token, defaults to: {{ github.token }}'
@@ -18,10 +17,9 @@ runs:
   steps:
     - name: Flip workflow
       run: |
+        echo "[INFO] Flipping workflow for ${{ github.repository }} workflow ID ${GITHUB_ACTION}"
         echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID ${{ inputs.workflow_id }}"
-        echo "[INFO] Flipping workflow for ${{ env.GITHUB_REPOSITORY }} workflow ID ${{ env.GITHUB_ACTION }}"
-        echo "[INFO] Flipping workflow for ${{ github.repository }} workflow ID ${{ github.action }}"
-        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/disable
-        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/enable
+        WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ github.repository }}/actions/workflows/${GITHUB_ACTION}"
+        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/disable"
+        curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/enable"
       shell: sh
-

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -3,9 +3,11 @@ description: "Disables and re-enables the running workflow to avoid 60 day CI di
 inputs:
   repository:
     description: 'The repository the workflow is in'
+    default: ${{ github.repository }}
     required: true
   workflow_id:
     description: 'A single Workflow ID'
+    default: ${{ github.action }}
     required: true
   access_token:
     description: 'Your GitHub Access Token, defaults to: {{ github.token }}'

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -22,7 +22,7 @@ runs:
         WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows"
         if [[ ${{ inputs.workflow }} == .github/* ]]; then
           echo "[INFO] Using filepath to find workflow ID: ${{ inputs.workflow }}"
-          WORKFLOW_FILE=$(awk -F'/' '{print $NF}' <<< "${{ inputs.workflow }}")
+          WORKFLOW_FILE=$(echo "${{ inputs.workflow }}" | awk -F '/' '{print $NF}')
           curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_FILE"
         else
           echo "[INFO] Using workflow name to find workflow ID: ${{ inputs.workflow }}"

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -31,4 +31,4 @@ runs:
         echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID $WORKFLOW_ID"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/disable"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/enable"
-      shell: sh
+      shell: bash

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -20,14 +20,22 @@ runs:
       run: |
         WORKFLOW_ID=""
         WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows"
+
         if [[ "${{ inputs.workflow }}" == .github/* ]]; then
           echo "[INFO] Using filepath to find workflow ID: ${{ inputs.workflow }}"
           WORKFLOW_FILE=$(echo "${{ inputs.workflow }}" | awk -F '/' '{print $NF}')
           WORKFLOW_ID=$(curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_FILE" | jq -r .id)
         else
           echo "[INFO] Using workflow name to find workflow ID: ${{ inputs.workflow }}"
-          curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT"
+          WORKFLOWS=$(curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT")
+          for wf in $(echo "${WORKFLOWS}"); do
+            WF_NAME=$(echo "$wf" | jq -r .workflows[].name)
+            if [[ "$WF_NAME" == "${{ inputs.workflow }}" ]]; then
+              WORKFLOW_ID=$(echo "$wf" | jq -r .workflows[].id)
+            fi
+          done
         fi
+
         echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID $WORKFLOW_ID"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/disable"
         curl -sX PUT -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT/$WORKFLOW_ID/enable"

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Flip workflow
       run: |
-        export WORKFLOW_ID
+        export WORKFLOW_ID=""
         WORKFLOW_API_ENDPOINT="https://api.github.com/repos/${{ inputs.repository }}/actions/workflows
 
         if [[ ${{ inputs.workflow }} == .github/* ]]; then

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -19,6 +19,8 @@ runs:
     - name: Flip workflow
       run: |
         echo "[INFO] Flipping workflow for ${{ inputs.repository }} workflow ID ${{ inputs.workflow_id }}"
+        echo "[INFO] Flipping workflow for ${{ env.GITHUB_REPOSITORY }} workflow ID ${{ env.GITHUB_ACTION }}"
+        echo "[INFO] Flipping workflow for ${{ github.repository }} workflow ID ${{ github.action }}"
         curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/disable
         curl -sX PUT -H "Authorization: token ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ inputs.repository }}/actions/workflows/${{ inputs.workflow_id }}/enable
       shell: sh

--- a/github/keep-alive/action.yml
+++ b/github/keep-alive/action.yml
@@ -28,10 +28,10 @@ runs:
         else
           echo "[INFO] Using workflow name to find workflow ID: ${{ inputs.workflow }}"
           WORKFLOWS=$(curl -s -H "Authorization: token ${{ inputs.access_token }}" -H "Accept: application/vnd.github.v3+json" "$WORKFLOW_API_ENDPOINT")
-          for wf in $(echo "${WORKFLOWS}"); do
-            WF_NAME=$(echo "$wf" | jq -r .workflows[].name)
+          for wf in $(echo "${WORKFLOWS}" | jq -c -r '.workflows[] | @base64'); do
+            WF_NAME=$(echo "$wf" | base64 --decode | jq -r .name)
             if [[ "$WF_NAME" == "${{ inputs.workflow }}" ]]; then
-              WORKFLOW_ID=$(echo "$wf" | jq -r .workflows[].id)
+              WORKFLOW_ID=$(echo "$wf" | base64 --decode | jq -r .id)
             fi
           done
         fi


### PR DESCRIPTION
So this keep alive workflow is meant to keep our cron-scheduled workflows from being disabled automatically by github for 60 days of repo inactivity. According to a GitHub staff member, disabling and re-enabling a workflow counts as activity. (See: https://github.community/t/no-notification-workflow-disabled-after-60-days/182169/5 ) So that's exactly what this action does. All you need to do to add this Action to a repo is add a separate job that runs on workflow runs, and it will disable and re-enable the currently running workflow. For ex:

```
jobs:
  workflow-keep-alive:
    runs-on: ubuntu-latest
    steps:
      - name: Flip workflow
        uses: Chia-Network/actions/github/keep-alive@main

...
```

This means if you have multiple scheduled workflows in a particular repo, you would need to add it to each of them.

A lot of commits went into this despite it being relatively simple because GitHub Actions has interesting and unexpected behavior with GitHub's default environment variables. 