### PR TITLE
Automatically acquire Python pre-releases

### DIFF
--- a/setup-python/action.yml
+++ b/setup-python/action.yml
@@ -33,7 +33,7 @@ runs:
       # Requires native m1 runner software, not x64 running via arch flags
       if: runner.arch != 'ARM64'
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ format('{0}.0-alpha - {0}.X', inputs.python-version) }}
         architecture: ${{ inputs.architecture }}
         cache: ${{ inputs.cache }}
         token: ${{ inputs.token }}


### PR DESCRIPTION
This avoids the need to specifically request pre-releases.  This means that you don't have to know to request it nor do you have to update the version requested when it progresses from alpha to beta to release.