### PR TITLE
Make activate-venv work in Docker

### DIFF
--- a/.github/workflows/test-activate-venv.yml
+++ b/.github/workflows/test-activate-venv.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.runs-on }}
+    container: ${{ matrix.os.container }}
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +30,10 @@ jobs:
           - name: Ubuntu
             matrix: ubuntu
             runs-on: ubuntu-latest
+          - name: Ubuntu Docker
+            matrix: docker
+            runs-on: ubuntu-latest
+            container: ubuntu
           - name: Windows
             matrix: windows
             runs-on: windows-latest

--- a/.github/workflows/test-activate-venv.yml
+++ b/.github/workflows/test-activate-venv.yml
@@ -41,9 +41,6 @@ jobs:
           - name: '3.9'
             action: '3.9'
 
-    env:
-      PYTHON_EXECUTABLE: /venv/${{ matrix.os.name == 'windows' && 'Scripts' || 'bin' }}/${{ matrix.os.name == 'windows' && 'python.exe' || 'python' }}
-
     steps:
     - uses: actions/checkout@v3
 
@@ -60,5 +57,7 @@ jobs:
       uses: ./activate-venv/
 
     - name: Check environment is activated
+      env:
+        EXPECTED_EXECUTABLE: /venv/${{ matrix.os.name == 'windows' && 'Scripts' || 'bin' }}/${{ matrix.os.name == 'windows' && 'python.exe' || 'python' }}
       run: |
-        python -c "import os; import sys; sys.exit(0 if sys.executable.endswith(os.environ['PYTHON_EXECUTABLE']) else 1)"
+        python activate-venv/test_check_activated.py

--- a/.github/workflows/test-activate-venv.yml
+++ b/.github/workflows/test-activate-venv.yml
@@ -42,7 +42,7 @@ jobs:
             action: '3.9'
 
     env:
-      ENV_PATH: venv/${{ matrix.os.name == 'windows' && 'Scripts' || 'bin' }}/
+      PYTHON_EXECUTABLE: /venv/${{ matrix.os.name == 'windows' && 'Scripts' || 'bin' }}/${{ matrix.os.name == 'windows' && 'python.exe' || 'python' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -55,11 +55,10 @@ jobs:
     - name: Setup virtual environment
       run: |
         python -m venv venv
-        ${{ env.ENV_PATH }}/python -m pip install decorator
 
     - name: Run the action
       uses: ./activate-venv/
 
     - name: Check environment is activated
       run: |
-        python -c 'import decorator'
+        python -c 'import sys; sys.exit(0 if sys.executable.endswith("${{ env.PYTHON_EXECUTABLE }}") else 0)'

--- a/.github/workflows/test-activate-venv.yml
+++ b/.github/workflows/test-activate-venv.yml
@@ -61,4 +61,4 @@ jobs:
 
     - name: Check environment is activated
       run: |
-        python -c 'import sys; sys.exit(0 if sys.executable.endswith("${{ env.PYTHON_EXECUTABLE }}") else 0)'
+        python -c "import os; import sys; sys.exit(0 if sys.executable.endswith(os.environ['PYTHON_EXECUTABLE']) else 1)"

--- a/.github/workflows/test-activate-venv.yml
+++ b/.github/workflows/test-activate-venv.yml
@@ -58,6 +58,6 @@ jobs:
 
     - name: Check environment is activated
       env:
-        EXPECTED_EXECUTABLE: /venv/${{ matrix.os.name == 'windows' && 'Scripts' || 'bin' }}/${{ matrix.os.name == 'windows' && 'python.exe' || 'python' }}
+        EXPECTED_EXECUTABLE: ./venv/${{ matrix.os.name == 'windows' && 'Scripts' || 'bin' }}/${{ matrix.os.name == 'windows' && 'python.exe' || 'python' }}
       run: |
         python activate-venv/test_check_activated.py

--- a/activate-venv/action.yml
+++ b/activate-venv/action.yml
@@ -19,7 +19,7 @@ runs:
       if: runner.os == 'macos' || runner.os == 'linux'
       shell: sh
       run: |
-        for venv in $(echo '${{ inputs.directories }}' | jq -c -r '.[]')
+        for venv in ${{ join(fromJSON(inputs.directories), ' ') }}
         do
           if [ -d "${venv}" ]
           then
@@ -38,7 +38,7 @@ runs:
       if: runner.os == 'windows'
       shell: pwsh
       run: |
-        foreach ($venv in (echo '${{ inputs.directories }}' | jq -c  -r '.[]'))
+        foreach ($venv in ${{ join(fromJSON(inputs.directories), ' ') }})
         {
           if (Test-Path -PathType Container "$venv") {
             "$venv/Scripts/activate"

--- a/activate-venv/action.yml
+++ b/activate-venv/action.yml
@@ -19,7 +19,7 @@ runs:
       if: runner.os == 'macos' || runner.os == 'linux'
       shell: sh
       run: |
-        for venv in ${{ join(fromJSON(inputs.directories), ' ') }}
+        for venv in ${{ join(fromJSON(inputs.directories), '\n') }}
         do
           if [ -d "${venv}" ]
           then
@@ -38,7 +38,7 @@ runs:
       if: runner.os == 'windows'
       shell: pwsh
       run: |
-        foreach ($venv in ${{ join(fromJSON(inputs.directories), ' ') }})
+        foreach ($venv in ${{ join(fromJSON(inputs.directories), '\n') }})
         {
           if (Test-Path -PathType Container "$venv") {
             "$venv/Scripts/activate"

--- a/activate-venv/action.yml
+++ b/activate-venv/action.yml
@@ -19,7 +19,7 @@ runs:
       if: runner.os == 'macos' || runner.os == 'linux'
       shell: sh
       run: |
-        for venv in ${{ join(fromJSON(inputs.directories), '\n') }}
+        for venv in "${{ join(fromJSON(inputs.directories), '" "') }}"
         do
           if [ -d "${venv}" ]
           then
@@ -38,7 +38,7 @@ runs:
       if: runner.os == 'windows'
       shell: pwsh
       run: |
-        foreach ($venv in ${{ join(fromJSON(inputs.directories), '\n') }})
+        foreach ($venv in "${{ join(fromJSON(inputs.directories), '", "') }}")
         {
           if (Test-Path -PathType Container "$venv") {
             "$venv/Scripts/activate"

--- a/activate-venv/test_check_activated.py
+++ b/activate-venv/test_check_activated.py
@@ -3,6 +3,12 @@ import pathlib
 import sys
 
 expected = pathlib.Path.cwd().joinpath(os.environ["EXPECTED_EXECUTABLE"])
+actual = pathlib.Path(sys.executable)
+equal = expected == pathlib.Path(sys.executable)
 
-if expected != pathlib.Path(sys.executable):
+print(f"expected: {expected}")
+print(f"  actual: {actual}")
+print(f"   equal: {'yes' if equal else 'no'}")
+
+if not equal:
     sys.exit(1)

--- a/activate-venv/test_check_activated.py
+++ b/activate-venv/test_check_activated.py
@@ -4,5 +4,5 @@ import sys
 
 expected = pathlib.Path.cwd().joinpath(os.environ["EXPECTED_EXECUTABLE"])
 
-if not expected.samefile(sys.executable):
+if expected != pathlib.Path(sys.executable):
     sys.exit(1)

--- a/activate-venv/test_check_activated.py
+++ b/activate-venv/test_check_activated.py
@@ -1,0 +1,8 @@
+import os
+import pathlib
+import sys
+
+expected = pathlib.Path.cwd().joinpath(os.environ["EXPECTED_EXECUTABLE"])
+
+if not expected.samefile(sys.executable):
+    sys.exit(1)


### PR DESCRIPTION
The images tend not to have `jq`.  I will acknowledge that the substitute quoting is not robust against interesting env paths but mostly i don't expect us to pass in anything custom anyways.  When it fails we can enhance these tests and fix as needed.