### PR TITLE
add check-commit-signing action

### DIFF
--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Run the action
       uses: ./check-commit-signing/

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -30,10 +30,6 @@ jobs:
           - name: Ubuntu
             matrix: ubuntu
             runs-on: ubuntu-latest
-          - name: Ubuntu Docker
-            matrix: docker
-            runs-on: ubuntu-latest
-            container: ubuntu
           - name: Windows
             matrix: windows
             runs-on: windows-latest

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -37,17 +37,9 @@ jobs:
           - name: Windows
             matrix: windows
             runs-on: windows-latest
-        python:
-          - name: '3.9'
-            action: '3.9'
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Set up ${{ matrix.python.name }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python.action }}
 
     - name: Run the action
       uses: ./check-commit-signing/

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -45,11 +45,11 @@ jobs:
       id: unsigned_commit
       shell: bash
       run: |
-        git checkout '${{ github.event.pull_request.head.ref }}'
+        git checkout '${{ github.event.pull_request.head.sha }}'
         git config --local user.email "test@example.com"
         git config --local user.name "Test Committer"
         git commit --no-gpg-sign --allow-empty -m 'unsigned commit for testing'
-        echo "unsigned_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        echo "unsigned_hash=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
     - name: Run the action
       id: failure_check

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -1,0 +1,77 @@
+name: test-check-commit-signing
+
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - '**'
+  pull_request:
+    branches:
+    - '**'
+
+concurrency:
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.runs-on }}
+    container: ${{ matrix.os.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: macOS
+            matrix: macos
+            runs-on: macos-latest
+          - name: Ubuntu
+            matrix: ubuntu
+            runs-on: ubuntu-latest
+          - name: Ubuntu Docker
+            matrix: docker
+            runs-on: ubuntu-latest
+            container: ubuntu
+          - name: Windows
+            matrix: windows
+            runs-on: windows-latest
+        python:
+          - name: '3.9'
+            action: '3.9'
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up ${{ matrix.python.name }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python.action }}
+
+    - name: Run the action
+      uses: ./check-commit-signing/
+
+    - name: Create unsigned commit
+      id: unsigned_commit
+      shell: bash
+      run: |
+        git checkout ${{ github.pull_request.head.ref }}
+        git commit --no-gpg-sign --allow-empty -m 'unsigned commit for testing'
+        echo "unsigned_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Run the action
+      id: failure_check
+      uses: ./check-commit-signing/
+      with:
+        source: ${{ outputs.unsigned_commit.unsigned_hash }}
+
+    - name: Make sure unsigned check failed
+      if: always()
+      run: |
+        if [ "${{ outputs.failure_check.outputs.status }}" == "unsigned" ]
+        then
+          true
+        else
+          false
+        fi

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -61,6 +61,7 @@ jobs:
 
     - name: Make sure unsigned check failed
       if: always()
+      shell: bash
       run: |
         if [ "${{ steps.failure_check.outputs.status }}" == "unsigned" ]
         then

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -45,7 +45,7 @@ jobs:
       id: unsigned_commit
       shell: bash
       run: |
-        git checkout ${{ github.pull_request.head.ref }}
+        git checkout '${{ github.event.pull_request.head.ref }}'
         git config --local user.email "test@example.com"
         git config --local user.name "Test Committer"
         git commit --no-gpg-sign --allow-empty -m 'unsigned commit for testing'

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -58,6 +58,7 @@ jobs:
 
     - name: Run the action
       id: failure_check
+      continue-on-error: true
       uses: ./check-commit-signing/
       with:
         source: ${{ steps.unsigned_commit.outputs.unsigned_hash }}

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -64,12 +64,12 @@ jobs:
       id: failure_check
       uses: ./check-commit-signing/
       with:
-        source: ${{ outputs.unsigned_commit.unsigned_hash }}
+        source: ${{ steps.unsigned_commit.outputs.unsigned_hash }}
 
     - name: Make sure unsigned check failed
       if: always()
       run: |
-        if [ "${{ outputs.failure_check.outputs.status }}" == "unsigned" ]
+        if [ "${{ steps.failure_check.outputs.status }}" == "unsigned" ]
         then
           true
         else

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -49,6 +49,8 @@ jobs:
       shell: bash
       run: |
         git checkout ${{ github.pull_request.head.ref }}
+        git config --local user.email "test@example.com"
+        git config --local user.name "Test Committer"
         git commit --no-gpg-sign --allow-empty -m 'unsigned commit for testing'
         echo "unsigned_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -19,7 +19,6 @@ jobs:
   test:
     name: ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.runs-on }}
-    container: ${{ matrix.os.container }}
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository stores internal actions and workflows that will be reused in Git
 ### ansible/run-playbook
 Runs an ansible playbook against an inventory of hosts
 
+### check-commit-signing
+Checks that all commits in a PR have been signed.
+
 ### clean-workspace
 Cleans the current workspace prior to running the checkout action, to ensure the job starts with a clean slate.
 

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -1,0 +1,44 @@
+name: "Check unsigned commits"
+description: "Checks for unsigned commits being introduced and fails if present"
+
+inputs:
+  target:
+    description: ""
+    required: true
+    default: ${{ github.pull_request.base.sha }}
+  source:
+    description: ""
+    required: true
+    default: ${{ github.pull_request.head.sha }}
+  temporary_directory:
+    description: ""
+    required: true
+    default: ${{ env['RUNNER_TEMP'] }}
+
+outputs:
+  status:
+    description: "Set to either signed or unsigned accordingly."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for unsigned commits
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        git show ${{ inputs.target }}
+        git show ${{ inputs.source }}
+        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ inputs.temporary_directory }}/unsigned_commit_check_log"
+        echo
+        echo All commits in log:
+        cat "${{ inputs.temporary_directory }}/unsigned_commit_check_log"
+        echo
+        echo Commits in log considered unsigned:
+        if grep 'N$' "${{ inputs.temporary_directory }}/unsigned_commit_check_log"
+        then
+          echo "status=unsigned" >> $GITHUB_OUTPUT  
+          false
+        else
+          echo "status=signed" >> $GITHUB_OUTPUT
+          true
+        fi

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -21,18 +21,20 @@ runs:
     - name: Check for unsigned commits
       if: github.event_name == 'pull_request'
       shell: bash
+      env:
+        log: ${RUNNER_TEMP}/unsigned_commit_check_log.${{ github.run_id }}
       run: |
         echo Target:
         git show --no-patch ${{ inputs.target }}
         echo Source:
         git show --no-patch ${{ inputs.source }}
-        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env.RUNNER_TEMP }}/unsigned_commit_check_log"
+        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env.log }}"
         echo
         echo All commits in log:
-        cat "${{ env.RUNNER_TEMP }}/unsigned_commit_check_log"
+        cat "${{ env.log }}"
         echo
         echo Commits in log considered unsigned:
-        if grep 'N$' "${{ env.RUNNER_TEMP }}/unsigned_commit_check_log"
+        if grep 'N$' "${{ env.log }}"
         then
           echo "status=unsigned" >> $GITHUB_OUTPUT  
           false

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: ""
     required: true
     default: ${{ github.pull_request.head.sha }}
-  temporary_directory:
-    description: ""
-    required: true
-    default: ${{ env['RUNNER_TEMP'] }}
 
 outputs:
   status:
@@ -28,13 +24,13 @@ runs:
       run: |
         git show ${{ inputs.target }}
         git show ${{ inputs.source }}
-        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ inputs.temporary_directory }}/unsigned_commit_check_log"
+        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env['RUNNER_TEMP'] }}/unsigned_commit_check_log"
         echo
         echo All commits in log:
-        cat "${{ inputs.temporary_directory }}/unsigned_commit_check_log"
+        cat "${{ env['RUNNER_TEMP'] }}/unsigned_commit_check_log"
         echo
         echo Commits in log considered unsigned:
-        if grep 'N$' "${{ inputs.temporary_directory }}/unsigned_commit_check_log"
+        if grep 'N$' "${{ env['RUNNER_TEMP'] }}/unsigned_commit_check_log"
         then
           echo "status=unsigned" >> $GITHUB_OUTPUT  
           false

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -22,8 +22,10 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        git show ${{ inputs.target }}
-        git show ${{ inputs.source }}
+        echo Target:
+        git show --no-patch ${{ inputs.target }}
+        echo Source:
+        git show --no-patch ${{ inputs.source }}
         git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env['RUNNER_TEMP'] }}/unsigned_commit_check_log"
         echo
         echo All commits in log:

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -14,11 +14,13 @@ inputs:
 outputs:
   status:
     description: "Set to either signed or unsigned accordingly."
+    value: ${{ steps.check.outputs.status }}
 
 runs:
   using: "composite"
   steps:
     - name: Check for unsigned commits
+      id: check
       if: github.event_name == 'pull_request'
       shell: bash
       env:

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -5,11 +5,11 @@ inputs:
   target:
     description: ""
     required: true
-    default: ${{ github.pull_request.base.sha }}
+    default: ${{ github.event.pull_request.base.sha }}
   source:
     description: ""
     required: true
-    default: ${{ github.pull_request.head.sha }}
+    default: ${{ github.event.pull_request.head.sha }}
 
 outputs:
   status:
@@ -24,9 +24,9 @@ runs:
       env:
         log: ${RUNNER_TEMP}/unsigned_commit_check_log.${{ github.run_id }}
       run: |
-        echo Target: ${{ inputs.target }}
+        echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
-        echo Source: ${{ inputs.source }}
+        echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
         git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env.log }}"
         echo

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -24,9 +24,9 @@ runs:
       env:
         log: ${RUNNER_TEMP}/unsigned_commit_check_log.${{ github.run_id }}
       run: |
-        echo Target:
+        echo Target: ${{ inputs.target }}
         git show --no-patch ${{ inputs.target }}
-        echo Source:
+        echo Source: ${{ inputs.source }}
         git show --no-patch ${{ inputs.source }}
         git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env.log }}"
         echo

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -26,13 +26,13 @@ runs:
         git show --no-patch ${{ inputs.target }}
         echo Source:
         git show --no-patch ${{ inputs.source }}
-        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env['RUNNER_TEMP'] }}/unsigned_commit_check_log"
+        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env.RUNNER_TEMP }}/unsigned_commit_check_log"
         echo
         echo All commits in log:
-        cat "${{ env['RUNNER_TEMP'] }}/unsigned_commit_check_log"
+        cat "${{ env.RUNNER_TEMP }}/unsigned_commit_check_log"
         echo
         echo Commits in log considered unsigned:
-        if grep 'N$' "${{ env['RUNNER_TEMP'] }}/unsigned_commit_check_log"
+        if grep 'N$' "${{ env.RUNNER_TEMP }}/unsigned_commit_check_log"
         then
           echo "status=unsigned" >> $GITHUB_OUTPUT  
           false

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -38,9 +38,9 @@ runs:
         echo Commits in log considered unsigned:
         if grep 'N$' "${{ env.log }}"
         then
-          echo "status=unsigned" >> $GITHUB_OUTPUT  
+          echo "status=unsigned" >> "${GITHUB_OUTPUT}"
           false
         else
-          echo "status=signed" >> $GITHUB_OUTPUT
+          echo "status=signed" >> "${GITHUB_OUTPUT}"
           true
         fi

--- a/check-commit-signing/readme.md
+++ b/check-commit-signing/readme.md
@@ -1,0 +1,19 @@
+# Check that PR commits are signed
+
+Checks that all commits in a PR have been signed.
+GitHub's unsigned commit branch protections only provide notifications when the PR has at least been approved, which is far too late to be correcting the situation cleanly.
+This provides an earlier warning in PRs with unsigned commits.
+Signing is done at the time the git commit is created generally by either a GPG or SSH key.
+
+The commits checked are those that would be added to the target branch if the PR were merged.
+Historical commits already on both branches are not checked.
+This list of commits is identified using git's `...` diff option.
+
+```yaml
+- uses: Chia-Network/actions/check-commit-signing@main
+```
+
+There are two options that can be passed, `target` and `source`.
+They default to the PR base and head accordingly, but can be specified if special situations arise.
+
+This action only runs on PR triggers so the caller need not specify their own `if:` condition.


### PR DESCRIPTION
The purpose of this is to provide an earlier warning of unsigned commits in PRs across any number of repositories.  As is, the merge-requirement branch protection check enforcement isn't actually indicated to anyone until the PR is at least fully reviewed.  This is much too late to remedy the situation well.  The branch protection blocking of pushing of unsigned commits to a branch 1) only applies to our repository, not external contributor forks, and 2) does not block unsigned commits in the history of a new branch the first time it is pushed.  The latter is because if it did, you could never push any new branch with any unsigned commit anywhere in it's history, even those pile of unsigned commits we have from years ago.

Note the failing run in https://github.com/Chia-Network/actions/actions/runs/3474323270/jobs/5807355221 where I removed the creation of the unsigned commit to make sure the test of this action properly reports failure.  Testing with blockchain in https://github.com/Chia-Network/chia-blockchain/pull/13923 (success) and https://github.com/Chia-Network/chia-blockchain/pull/13924 (failure).

The biggest question here is what exact signing status do we require.  I'm not sure if we have access to any information to do anything beyond just 'was signed by something'.