### PR TITLE
Revert "Revert "add check-commit-signing action""

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -1,0 +1,25 @@
+name: 🚨 Check commit signing
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  check-commit-signing:
+    name: Check commit signing
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 5
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: chia-network/actions/check-commit-signing@main

--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -22,4 +22,4 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: chia-network/actions/check-commit-signing@main
+    - uses: ./check-commit-signing

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -41,75 +41,17 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup git
-      shell: bash
-      run: |
-        # TODO: but this means the local uses: references below don't use the merge
-        git checkout '${{ github.event.pull_request.head.sha }}'
-        git config --local user.email "test@example.com"
-        git config --local user.name "Test Committer"
-
-    - name: Setup GPG signing
-      shell: bash
-      run: |
-        git config gpg.format openpgp
-        git config commit.gpgsign true
-        # key created by:
-        # gpg --generate-key --batch check-commit-signing/gpg_key_script
-        # gpg --list-secret-keys --keyid-format long | sed -n 's;^sec .*/\([^ ]\+\) .*;\1;p' > gpg_key
-        git config user.signingKey 03FAE97C9F159187
-        # TODO: but doesn't it need the full secret key and this is just an identifier for that?
-
-    - name: Create GPG signed commit
-      id: gpg_signed_commit
-      shell: bash
-      run: |
-         git commit --gpg-sign --allow-empty -m 'gpg signed commit for testing'
-
-    - name: Clear signing configuration
-      shell: bash
-      run: |
-        git config commit.gpgsign false
-        git config user.signingKey ''
-
     - name: Check GPG signed commit
       uses: ./check-commit-signing/
       with:
-        source: ${{ steps.gpg_signed_commit.outputs.commit_hash }}
-
-    - name: Setup SSH signing
-      shell: bash
-      run: |
-        git config gpg.format ssh
-        git config commit.gpgsign true
-        # key created by:
-        # ssh-keygen -t ed25519 -C 'test' -f ssh_keyfile -N justtesting
-        # cat ssh_keyfile.pub
-        git config user.signingKey ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHtMirnQ7ggCOHz8THdO03fLFzrJychk468PaoSK6Cn1 test
-        # TODO: but doesn't it need the full secret key and this is just an identifier for that?
-
-    - name: Create SSH signed commit
-      id: ssh_signed_commit
-      shell: bash
-      run: |
-         git commit --gpg-sign --allow-empty -m 'ssh signed commit for testing'
-
-    - name: Clear signing configuration
-      shell: bash
-      run: |
-        git config commit.gpgsign false
-        git config user.signingKey ''
+        source: 099b4d5e3114f8d065b81f89f5bd9d20b42cd7eb
+        target: 099b4d5e3114f8d065b81f89f5bd9d20b42cd7eb^
 
     - name: Check SSH signed commit
       uses: ./check-commit-signing/
       with:
-        source: ${{ steps.ssh_signed_commit.outputs.commit_hash }}
-
-    - name: Clear signing configuration
-      shell: bash
-      run: |
-        git config commit.gpgsign false
-        git config user.signingKey ''
+        source: 63dab4d7ed40084e208d8d50805af749740a386a
+        target: 63dab4d7ed40084e208d8d50805af749740a386a^
 
     - name: Create unsigned commit
       id: unsigned_commit

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
   cancel-in-progress: true
 
+env:
+  GIT_TRACE: 1
+
 jobs:
   test:
     name: ${{ matrix.os.name }}

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -1,0 +1,70 @@
+name: test-check-commit-signing
+
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - '**'
+  pull_request:
+    branches:
+    - '**'
+
+concurrency:
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: macOS
+            matrix: macos
+            runs-on: macos-latest
+          - name: Ubuntu
+            matrix: ubuntu
+            runs-on: ubuntu-latest
+          - name: Windows
+            matrix: windows
+            runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Run the action
+      uses: ./check-commit-signing/
+
+    - name: Create unsigned commit
+      id: unsigned_commit
+      shell: bash
+      run: |
+        git checkout '${{ github.event.pull_request.head.sha }}'
+        git config --local user.email "test@example.com"
+        git config --local user.name "Test Committer"
+        git commit --no-gpg-sign --allow-empty -m 'unsigned commit for testing'
+        echo "unsigned_hash=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+    - name: Run the action
+      id: failure_check
+      continue-on-error: true
+      uses: ./check-commit-signing/
+      with:
+        source: ${{ steps.unsigned_commit.outputs.unsigned_hash }}
+
+    - name: Make sure unsigned check failed
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ steps.failure_check.outputs.status }}" == "unsigned" ]
+        then
+          true
+        else
+          false
+        fi

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -39,7 +39,6 @@ jobs:
         fetch-depth: 0
 
     - name: Setup git
-      id: unsigned_commit
       shell: bash
       run: |
         # TODO: but this means the local uses: references below don't use the merge
@@ -64,6 +63,12 @@ jobs:
       run: |
          git commit --gpg-sign --allow-empty -m 'gpg signed commit for testing'
 
+    - name: Clear signing configuration
+      shell: bash
+      run: |
+        git config commit.gpgsign false
+        git config user.signingKey ''
+
     - name: Check GPG signed commit
       uses: ./check-commit-signing/
       with:
@@ -85,6 +90,12 @@ jobs:
       shell: bash
       run: |
          git commit --gpg-sign --allow-empty -m 'ssh signed commit for testing'
+
+    - name: Clear signing configuration
+      shell: bash
+      run: |
+        git config commit.gpgsign false
+        git config user.signingKey ''
 
     - name: Check SSH signed commit
       uses: ./check-commit-signing/

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup GPG signing
       shell: bash
       run: |
-        git config gpg.format gpg
+        git config gpg.format openpgp
         git config commit.gpgsign true
         # key created by:
         # gpg --generate-key --batch check-commit-signing/gpg_key_script

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -38,25 +38,78 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Run the action
+    - name: Setup git
+      id: unsigned_commit
+      shell: bash
+      run: |
+        # TODO: but this means the local uses: references below don't use the merge
+        git checkout '${{ github.event.pull_request.head.sha }}'
+        git config --local user.email "test@example.com"
+        git config --local user.name "Test Committer"
+
+    - name: Setup GPG signing
+      shell: bash
+      run: |
+        git config gpg.format gpg
+        git config commit.gpgsign true
+        # key created by:
+        # gpg --generate-key --batch check-commit-signing/gpg_key_script
+        # gpg --list-secret-keys --keyid-format long | sed -n 's;^sec .*/\([^ ]\+\) .*;\1;p' > gpg_key
+        git config user.signingKey 03FAE97C9F159187
+        # TODO: but doesn't it need the full secret key and this is just an identifier for that?
+
+    - name: Create GPG signed commit
+      id: gpg_signed_commit
+      shell: bash
+      run: |
+         git commit --gpg-sign --allow-empty -m 'gpg signed commit for testing'
+
+    - name: Check GPG signed commit
       uses: ./check-commit-signing/
+      with:
+        source: ${{ steps.gpg_signed_commit.outputs.commit_hash }}
+
+    - name: Setup SSH signing
+      shell: bash
+      run: |
+        git config gpg.format ssh
+        git config commit.gpgsign true
+        # key created by:
+        # ssh-keygen -t ed25519 -C 'test' -f ssh_keyfile -N justtesting
+        # cat ssh_keyfile.pub
+        git config user.signingKey ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHtMirnQ7ggCOHz8THdO03fLFzrJychk468PaoSK6Cn1 test
+        # TODO: but doesn't it need the full secret key and this is just an identifier for that?
+
+    - name: Create SSH signed commit
+      id: ssh_signed_commit
+      shell: bash
+      run: |
+         git commit --gpg-sign --allow-empty -m 'ssh signed commit for testing'
+
+    - name: Check SSH signed commit
+      uses: ./check-commit-signing/
+      with:
+        source: ${{ steps.ssh_signed_commit.outputs.commit_hash }}
+
+    - name: Clear signing configuration
+      shell: bash
+      run: |
+        git config commit.gpgsign false
+        git config user.signingKey ''
 
     - name: Create unsigned commit
       id: unsigned_commit
       shell: bash
       run: |
-        git checkout '${{ github.event.pull_request.head.sha }}'
-        git config --local user.email "test@example.com"
-        git config --local user.name "Test Committer"
         git commit --no-gpg-sign --allow-empty -m 'unsigned commit for testing'
-        echo "unsigned_hash=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+        echo "commit_hash=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
-    - name: Run the action
+    - name: Check unsigned commit
       id: failure_check
       continue-on-error: true
       uses: ./check-commit-signing/
       with:
-        source: ${{ steps.unsigned_commit.outputs.unsigned_hash }}
+        source: ${{ steps.unsigned_commit.outputs.commit_hash }}
 
     - name: Make sure unsigned check failed
       if: always()

--- a/.github/workflows/test-check-commit-signing.yml
+++ b/.github/workflows/test-check-commit-signing.yml
@@ -53,6 +53,12 @@ jobs:
         source: 63dab4d7ed40084e208d8d50805af749740a386a
         target: 63dab4d7ed40084e208d8d50805af749740a386a^
 
+    - name: Setup git for unsigned committing
+      shell: bash
+      run: |
+        git config --local user.email "test@example.com"
+        git config --local user.name "Test Committer"
+
     - name: Create unsigned commit
       id: unsigned_commit
       shell: bash
@@ -66,6 +72,7 @@ jobs:
       uses: ./check-commit-signing/
       with:
         source: ${{ steps.unsigned_commit.outputs.commit_hash }}
+        target: ${{ steps.unsigned_commit.outputs.commit_hash }}^
 
     - name: Make sure unsigned check failed
       if: always()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository stores internal actions and workflows that will be reused in Git
 ### ansible/run-playbook
 Runs an ansible playbook against an inventory of hosts
 
+### check-commit-signing
+Checks that all commits in a PR have been signed.
+
 ### clean-workspace
 Cleans the current workspace prior to running the checkout action, to ensure the job starts with a clean slate.
 

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -60,6 +60,8 @@ runs:
         cat "${{ env.unsigned_log }}"
         echo '    ----'
 
+        echo "FAIL: ->${FAIL}<-"
+
         if [ "${FAIL}" == "nope" ]
         then
           echo "status=signed" >> "${GITHUB_OUTPUT}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -48,9 +48,9 @@ runs:
             true
           else
             cat "${{ env.single_log }}" >> "${{ env.unsigned_log }}"
-            echo about to FAIL=yes, fail was ->${FAIL}<-
+            echo "about to FAIL=yes, fail was ->${FAIL}<-"
             FAIL=yes
-            echo just FAIL=yes, fail is ->${FAIL}<-
+            echo "just FAIL=yes, fail is ->${FAIL}<-"
           fi
         done
 

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -39,8 +39,9 @@ runs:
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
         | while read hash; \
         do \
-          git verify-commit ${hash} |& grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
-          if [ "$?" == "0" ]; \
+          git verify-commit ${hash} &> verify_output
+          cat verify_output
+          if cat verify_output | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
           then \
             echo status: commit was signed in some way: ${hash}; \
           else \

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -62,6 +62,6 @@ runs:
         then
           echo "status=signed" >> "${GITHUB_OUTPUT}"
         else
-          echo "status=signed" >> "${GITHUB_OUTPUT}"
+          echo "status=unsigned" >> "${GITHUB_OUTPUT}"
           false
         fi

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -34,13 +34,15 @@ runs:
         echo
         echo All commits in log:
         cat "${{ env.log }}"
-        echo
-        echo Commits in log considered unsigned:
-        if grep 'N$' "${{ env.log }}"
-        then
-          echo "status=unsigned" >> "${GITHUB_OUTPUT}"
-          false
-        else
-          echo "status=signed" >> "${GITHUB_OUTPUT}"
-          true
-        fi
+        # TODO: abominable bash
+        ((git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash; do echo ____    ${hash}; git verify-commit ${hash} |& grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)'; if [ "$?" == "0" ]; then echo yep; else exit 1; fi; done)
+#        echo
+#        echo Commits in log considered unsigned:
+#        if grep 'N$' "${{ env.log }}"
+#        then
+#          echo "status=unsigned" >> "${GITHUB_OUTPUT}"
+#          false
+#        else
+#          echo "status=signed" >> "${GITHUB_OUTPUT}"
+#          true
+#        fi

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -24,22 +24,20 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       env:
-        hashes: ${RUNNER_TEMP}/hashes.${{ github.run_id }}
         unsigned_log: ${RUNNER_TEMP}/unsigned_commits.${{ github.run_id }}
         all_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
         single_log: ${RUNNER_TEMP}/single_commit.${{ github.run_id }}
         verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
         # TODO: make them more unique
-        rm -f "${{ env.hashes }}" "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
+        rm -f "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
         echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
         touch "${{ env.unsigned_log }}"
         export CHIA_CI_FAIL=nope
-        (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) > "${{ env.hashes }}"
-        while read hash < "${{ env.hashes }}"
+        (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash
         do
           (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
           (git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash}; echo) > "${{ env.single_log }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -29,6 +29,8 @@ runs:
         single_log: ${RUNNER_TEMP}/single_commit.${{ github.run_id }}
         verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
+        # TODO: make them more unique
+        rm -f "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
         echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
         echo Source: '${{ inputs.source }}'

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -1,0 +1,46 @@
+name: "Check unsigned commits"
+description: "Checks for unsigned commits being introduced and fails if present"
+
+inputs:
+  target:
+    description: ""
+    required: true
+    default: ${{ github.event.pull_request.base.sha }}
+  source:
+    description: ""
+    required: true
+    default: ${{ github.event.pull_request.head.sha }}
+
+outputs:
+  status:
+    description: "Set to either signed or unsigned accordingly."
+    value: ${{ steps.check.outputs.status }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for unsigned commits
+      id: check
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        log: ${RUNNER_TEMP}/unsigned_commit_check_log.${{ github.run_id }}
+      run: |
+        echo Target: '${{ inputs.target }}'
+        git show --no-patch ${{ inputs.target }}
+        echo Source: '${{ inputs.source }}'
+        git show --no-patch ${{ inputs.source }}
+        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env.log }}"
+        echo
+        echo All commits in log:
+        cat "${{ env.log }}"
+        echo
+        echo Commits in log considered unsigned:
+        if grep 'N$' "${{ env.log }}"
+        then
+          echo "status=unsigned" >> "${GITHUB_OUTPUT}"
+          false
+        else
+          echo "status=signed" >> "${GITHUB_OUTPUT}"
+          true
+        fi

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -25,38 +25,38 @@ runs:
       shell: bash
       env:
         statuses: ${RUNNER_TEMP}/statuses.${{ github.run_id }}
-        unsigned_log: ${RUNNER_TEMP}/unsigned_commits.${{ github.run_id }}
-        all_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
+        commit_log: ${RUNNER_TEMP}/commit_log.${{ github.run_id }}
         single_log: ${RUNNER_TEMP}/single_commit.${{ github.run_id }}
         verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
         # TODO: make them more unique
-        rm -f "${{ env.statuses }}" "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
+        rm -f "${{ env.statuses }}" "${{ env.commit_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
         echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
-        touch "${{ env.unsigned_log }}"
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash
         do
           (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
           (git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash}; echo) > "${{ env.single_log }}"
-          cat "${{ env.single_log }}" >> "${{ env.all_log }}"
           if cat "${{ env.verify_output }}" | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
           then
+            echo -n '  signed: ' >> "${{ env.commit_log }}"
+            cat "${{ env.single_log }}" >> "${{ env.commit_log }}"
             echo signed >> "${{ env.statuses }}"
           else
-            cat "${{ env.single_log }}" >> "${{ env.unsigned_log }}"
+            echo -n 'UNSIGNED: ' >> "${{ env.commit_log }}"
+            cat "${{ env.single_log }}" >> "${{ env.commit_log }}"
             echo unsigned >> "${{ env.statuses }}"
           fi
         done
 
         echo '    ---- All commits in log:'
-        cat "${{ env.all_log }}"
+        cat "${{ env.commit_log }}"
         echo '    ----'
 
         echo '    ---- Unsigned commits in log:'
-        cat "${{ env.unsigned_log }}"
+        grep '^UNSIGNED:' "${{ env.commit_log }}"
         echo '    ----'
 
         if grep '^unsigned$' "${{ env.statuses }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -38,8 +38,8 @@ runs:
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
         | while read hash
         do
-          git verify-commit ${hash} &> "${{ env.verify_output }}" || true
-          git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash} > "${{ env.single_log }}"
+          (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
+          (git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash}; echo) > "${{ env.single_log }}"
           cat "${{ env.single_log }}" >> "${{ env.all_log }}"
           if cat "${{ env.verify_output }}" | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
           then

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -24,40 +24,43 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       env:
-        log: ${RUNNER_TEMP}/unsigned_commit_check_log.${{ github.run_id }}
+        unsigned_log: ${RUNNER_TEMP}/unsigned_commits.${{ github.run_id }}
+        all_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
+        single_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
+        verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
         echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
-        git log --left-right --oneline --pretty='format:%H|%aN|%aI|%s|%G?' ${{ inputs.target }}...${{ inputs.source }} > "${{ env.log }}"
-        echo
-        echo All commits in log:
-        cat "${{ env.log }}"
-        # TODO: abominable bash
-        set -vx
+        FAIL=nope
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
-        | while read hash; \
-        do \
-          git verify-commit ${hash} &> verify_output || true
-          cat verify_output
-          if cat verify_output | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
-          then \
-            echo "status=signed" >> "${GITHUB_OUTPUT}"
-            echo status: commit was signed in some way: ${hash}; \
-          else \
-            echo "status=unsigned" >> "${GITHUB_OUTPUT}"
-            echo status: commit was not signed: ${hash}; \
-            exit 1; \
-          fi; \
+        | while read hash
+        do
+          git verify-commit ${hash} &> '${{ env.verify_output }}' || true
+          git show --pretty='format:%H|%aN|%aI|%s' ${hash} > '${{ env.single_log }}'
+          cat '${{ env.single_log }}' >> '${{ env.all_log }}'
+          if cat '${{ env.verify_output }}' | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
+          then
+            true
+          else
+            cat '${{ env.single_log }}' >> '${{ env.unsigned_log }}'
+            FAIL=yes
+          fi
         done
-#        echo
-#        echo Commits in log considered unsigned:
-#        if grep 'N$' "${{ env.log }}"
-#        then
-#          echo "status=unsigned" >> "${GITHUB_OUTPUT}"
-#          false
-#        else
-#          echo "status=signed" >> "${GITHUB_OUTPUT}"
-#          true
-#        fi
+
+        echo '    ---- All commits in log:'
+        cat '${{ env.all_log }}'
+        echo '    ----'
+
+        echo '    ---- Unsigned commits in log:'
+        cat '${{ env.unsigned_log }}'
+        echo '    ----'
+
+        if [ "${FAIL}" == "nope" ]
+        then
+          echo "status=signed" >> "${GITHUB_OUTPUT}"
+        else
+          echo "status=signed" >> "${GITHUB_OUTPUT}"
+          false
+        fi

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -39,7 +39,7 @@ runs:
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
         | while read hash; \
         do \
-          git verify-commit ${hash} 2>&1 | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
+          git verify-commit ${hash} |& grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
           if [ "$?" == "0" ]; \
           then \
             echo status: commit was signed in some way: ${hash}; \

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -39,7 +39,7 @@ runs:
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
         | while read hash; \
         do \
-          git verify-commit ${hash} &> verify_output
+          git verify-commit ${hash} &> verify_output || true
           cat verify_output
           if cat verify_output | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
           then \

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -48,6 +48,7 @@ runs:
             true
           else
             cat "${{ env.single_log }}" >> "${{ env.unsigned_log }}"
+            echo about to FAIL=yes
             FAIL=yes
           fi
         done

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -43,8 +43,10 @@ runs:
           cat verify_output
           if cat verify_output | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
           then \
+            echo "status=signed" >> "${GITHUB_OUTPUT}"
             echo status: commit was signed in some way: ${hash}; \
           else \
+            echo "status=unsigned" >> "${GITHUB_OUTPUT}"
             echo status: commit was not signed: ${hash}; \
             exit 1; \
           fi; \

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -48,8 +48,9 @@ runs:
             true
           else
             cat "${{ env.single_log }}" >> "${{ env.unsigned_log }}"
-            echo about to FAIL=yes
+            echo about to FAIL=yes, fail was ->${FAIL}<-
             FAIL=yes
+            echo just FAIL=yes, fail is ->${FAIL}<-
           fi
         done
 

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -33,6 +33,7 @@ runs:
         git show --no-patch ${{ inputs.target }}
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
+        touch "${{ env.unsigned_log }}"
         FAIL=nope
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
         | while read hash

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -24,19 +24,19 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       env:
+        statuses: ${RUNNER_TEMP}/statuses.${{ github.run_id }}
         unsigned_log: ${RUNNER_TEMP}/unsigned_commits.${{ github.run_id }}
         all_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
         single_log: ${RUNNER_TEMP}/single_commit.${{ github.run_id }}
         verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
         # TODO: make them more unique
-        rm -f "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
+        rm -f "${{ env.statuses }}" "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
         echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
         touch "${{ env.unsigned_log }}"
-        export CHIA_CI_FAIL=nope
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash
         do
           (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
@@ -44,12 +44,10 @@ runs:
           cat "${{ env.single_log }}" >> "${{ env.all_log }}"
           if cat "${{ env.verify_output }}" | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
           then
-            true
+            echo signed >> "${{ env.statuses }}"
           else
             cat "${{ env.single_log }}" >> "${{ env.unsigned_log }}"
-            echo "about to CHIA_CI_FAIL=yes, CHIA_CI_FAIL was ->${CHIA_CI_FAIL}<-"
-            export CHIA_CI_FAIL=yes
-            echo "just CHIA_CI_FAIL=yes, CHIA_CI_FAIL is ->${CHIA_CI_FAIL}<-"
+            echo unsigned >> "${{ env.statuses }}"
           fi
         done
 
@@ -61,12 +59,10 @@ runs:
         cat "${{ env.unsigned_log }}"
         echo '    ----'
 
-        echo "CHIA_CI_FAIL: ->${CHIA_CI_FAIL}<-"
-
-        if [ "${CHIA_CI_FAIL}" == "nope" ]
+        if grep '^unsigned$' "${{ env.statuses }}"
         then
-          echo "status=signed" >> "${GITHUB_OUTPUT}"
-        else
           echo "status=unsigned" >> "${GITHUB_OUTPUT}"
           false
+        else
+          echo "status=signed" >> "${GITHUB_OUTPUT}"
         fi

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -38,7 +38,7 @@ runs:
         | while read hash
         do
           git verify-commit ${hash} &> "${{ env.verify_output }}" || true
-          git show --pretty='format:%H|%aN|%aI|%s' ${hash} > "${{ env.single_log }}"
+          git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash} > "${{ env.single_log }}"
           cat "${{ env.single_log }}" >> "${{ env.all_log }}"
           if cat "${{ env.verify_output }}" | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
           then

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -39,12 +39,12 @@ runs:
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
         | while read hash; \
         do \
-          echo ____    ${hash}; \
-          git verify-commit ${hash} 2>&1 | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)'; \
+          git verify-commit ${hash} 2>&1 | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null; \
           if [ "$?" == "0" ]; \
           then \
-            echo yep; \
+            echo status: commit was signed in some way: ${hash}; \
           else \
+            echo status: commit was not signed: ${hash}; \
             exit 1; \
           fi; \
         done

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -24,20 +24,22 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       env:
+        hashes: ${RUNNER_TEMP}/hashes.${{ github.run_id }}
         unsigned_log: ${RUNNER_TEMP}/unsigned_commits.${{ github.run_id }}
         all_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
         single_log: ${RUNNER_TEMP}/single_commit.${{ github.run_id }}
         verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
         # TODO: make them more unique
-        rm -f "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
+        rm -f "${{ env.hashes }}" "${{ env.unsigned_log }}" "${{ env.all_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
         echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
         touch "${{ env.unsigned_log }}"
         export CHIA_CI_FAIL=nope
-        (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash
+        (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) > "${{ env.hashes }}"
+        while read hash < "${{ env.hashes }}"
         do
           (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
           (git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash}; echo) > "${{ env.single_log }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -39,7 +39,7 @@ runs:
         do
           (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
           (git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash}; echo) > "${{ env.single_log }}"
-          if cat "${{ env.verify_output }}" | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
+          if grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' "${{ env.verify_output }}" > /dev/null
           then
             echo -n '  signed: ' >> "${{ env.commit_log }}"
             cat "${{ env.single_log }}" >> "${{ env.commit_log }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -35,7 +35,19 @@ runs:
         echo All commits in log:
         cat "${{ env.log }}"
         # TODO: abominable bash
-        ((git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash; do echo ____    ${hash}; git verify-commit ${hash} 2>&1 | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)'; if [ "$?" == "0" ]; then echo yep; else exit 1; fi; done)
+        set -vx
+        (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
+        | while read hash; \
+        do \
+          echo ____    ${hash}; \
+          git verify-commit ${hash} 2>&1 | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)'; \
+          if [ "$?" == "0" ]; \
+          then \
+            echo yep; \
+          else \
+            exit 1; \
+          fi; \
+        done
 #        echo
 #        echo Commits in log considered unsigned:
 #        if grep 'N$' "${{ env.log }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -37,24 +37,24 @@ runs:
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
         | while read hash
         do
-          git verify-commit ${hash} &> '${{ env.verify_output }}' || true
-          git show --pretty='format:%H|%aN|%aI|%s' ${hash} > '${{ env.single_log }}'
-          cat '${{ env.single_log }}' >> '${{ env.all_log }}'
-          if cat '${{ env.verify_output }}' | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
+          git verify-commit ${hash} &> "${{ env.verify_output }}" || true
+          git show --pretty='format:%H|%aN|%aI|%s' ${hash} > "${{ env.single_log }}"
+          cat "${{ env.single_log }}" >> "${{ env.all_log }}"
+          if cat "${{ env.verify_output }}" | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' > /dev/null
           then
             true
           else
-            cat '${{ env.single_log }}' >> '${{ env.unsigned_log }}'
+            cat "${{ env.single_log }}" >> "${{ env.unsigned_log }}"
             FAIL=yes
           fi
         done
 
         echo '    ---- All commits in log:'
-        cat '${{ env.all_log }}'
+        cat "${{ env.all_log }}"
         echo '    ----'
 
         echo '    ---- Unsigned commits in log:'
-        cat '${{ env.unsigned_log }}'
+        cat "${{ env.unsigned_log }}"
         echo '    ----'
 
         if [ "${FAIL}" == "nope" ]

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -36,9 +36,8 @@ runs:
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
         touch "${{ env.unsigned_log }}"
-        FAIL=nope
-        (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) \
-        | while read hash
+        export CHIA_CI_FAIL=nope
+        (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash
         do
           (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
           (git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash}; echo) > "${{ env.single_log }}"
@@ -48,9 +47,9 @@ runs:
             true
           else
             cat "${{ env.single_log }}" >> "${{ env.unsigned_log }}"
-            echo "about to FAIL=yes, fail was ->${FAIL}<-"
-            FAIL=yes
-            echo "just FAIL=yes, fail is ->${FAIL}<-"
+            echo "about to CHIA_CI_FAIL=yes, CHIA_CI_FAIL was ->${CHIA_CI_FAIL}<-"
+            export CHIA_CI_FAIL=yes
+            echo "just CHIA_CI_FAIL=yes, CHIA_CI_FAIL is ->${CHIA_CI_FAIL}<-"
           fi
         done
 
@@ -62,9 +61,9 @@ runs:
         cat "${{ env.unsigned_log }}"
         echo '    ----'
 
-        echo "FAIL: ->${FAIL}<-"
+        echo "CHIA_CI_FAIL: ->${CHIA_CI_FAIL}<-"
 
-        if [ "${FAIL}" == "nope" ]
+        if [ "${CHIA_CI_FAIL}" == "nope" ]
         then
           echo "status=signed" >> "${GITHUB_OUTPUT}"
         else

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -35,7 +35,7 @@ runs:
         echo All commits in log:
         cat "${{ env.log }}"
         # TODO: abominable bash
-        ((git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash; do echo ____    ${hash}; git verify-commit ${hash} |& grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)'; if [ "$?" == "0" ]; then echo yep; else exit 1; fi; done)
+        ((git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash; do echo ____    ${hash}; git verify-commit ${hash} 2>&1 | grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)'; if [ "$?" == "0" ]; then echo yep; else exit 1; fi; done)
 #        echo
 #        echo Commits in log considered unsigned:
 #        if grep 'N$' "${{ env.log }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -56,7 +56,7 @@ runs:
         echo '    ----'
 
         echo '    ---- Unsigned commits in log:'
-        grep '^UNSIGNED:' "${{ env.commit_log }}"
+        grep '^UNSIGNED:' "${{ env.commit_log }}" || true
         echo '    ----'
 
         if grep '^unsigned$' "${{ env.statuses }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -30,15 +30,29 @@ runs:
         verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
         # TODO: make them more unique
+        # Make sure not to reuse temporary files if this action was already run.
         rm -f "${{ env.statuses }}" "${{ env.commit_log }}" "${{ env.single_log }}" "${{ env.verify_output }}"
+
         echo Target: '${{ inputs.target }}'
         git show --no-patch ${{ inputs.target }}
+        echo
+        echo
         echo Source: '${{ inputs.source }}'
         git show --no-patch ${{ inputs.source }}
+
+        # The (git <something>; echo) form adds back the trailing newline that git
+        # skips when piping or redirection output.
+
         (git log --left-right --oneline --pretty=format:%H ${{ inputs.target }}...${{ inputs.source }}; echo) | while read hash
         do
           (git verify-commit ${hash}; echo) &> "${{ env.verify_output }}" || true
+
+          # collect the single line log entry
           (git show --no-patch --pretty='format:%H|%aN|%aI|%s' ${hash}; echo) > "${{ env.single_log }}"
+
+          # Check the verify output for signature made from an openpgp signed commit
+          # or config needed from an ssh signed commit.  We're allowing _any_
+          # signature without verifying it.
           if grep -E '(Signature made|gpg.ssh.allowedSignersFile needs to be configured)' "${{ env.verify_output }}" > /dev/null
           then
             echo -n '  signed: ' >> "${{ env.commit_log }}"

--- a/check-commit-signing/action.yml
+++ b/check-commit-signing/action.yml
@@ -26,7 +26,7 @@ runs:
       env:
         unsigned_log: ${RUNNER_TEMP}/unsigned_commits.${{ github.run_id }}
         all_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
-        single_log: ${RUNNER_TEMP}/all_commits.${{ github.run_id }}
+        single_log: ${RUNNER_TEMP}/single_commit.${{ github.run_id }}
         verify_output: ${RUNNER_TEMP}/verify_output.${{ github.run_id }}
       run: |
         echo Target: '${{ inputs.target }}'

--- a/check-commit-signing/gpg_key_script
+++ b/check-commit-signing/gpg_key_script
@@ -1,3 +1,0 @@
-Key-Type: 1
-Name-Real: test
-%no-protection

--- a/check-commit-signing/gpg_key_script
+++ b/check-commit-signing/gpg_key_script
@@ -1,0 +1,3 @@
+Key-Type: 1
+Name-Real: test
+%no-protection

--- a/check-commit-signing/readme.md
+++ b/check-commit-signing/readme.md
@@ -1,0 +1,19 @@
+# Check that PR commits are signed
+
+Checks that all commits in a PR have been signed.
+GitHub's unsigned commit branch protections only provide notifications when the PR has at least been approved, which is far too late to be correcting the situation cleanly.
+This provides an earlier warning in PRs with unsigned commits.
+Signing is done at the time the git commit is created generally by either a GPG or SSH key.
+
+The commits checked are those that would be added to the target branch if the PR were merged.
+Historical commits already on both branches are not checked.
+This list of commits is identified using git's `...` diff option.
+
+```yaml
+- uses: Chia-Network/actions/check-commit-signing@main
+```
+
+There are two options that can be passed, `target` and `source`.
+They default to the PR base and head accordingly, but can be specified if special situations arise.
+
+This action only runs on PR triggers so the caller need not specify their own `if:` condition.


### PR DESCRIPTION
This action goes out of it's way to simply check if the commits are signed at all without verifying any of the signatures.  If, or when, signature checks are wanted there may be interest in https://github.com/frankywahl/allowedSignersFile or similar to collect ssh keys from GitHub to check against.

Reverts Chia-Network/actions#66

https://github.com/Chia-Network/actions/actions/runs/3599290314/jobs/6062780993#step:3:45
> `error: gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification`

Draft for:
- [x] testing with an ssh signed commit
- [x] making it work with an ssh signed commit