### PR TITLE
Reduced GraphQL query for `label-conflict` action

### DIFF
--- a/label-conflict/CHANGELOG.md
+++ b/label-conflict/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [2.0.0]
+### Breaking change
+- Removed `core.setOutput()` because it was deprecated
+  (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)  
+  Starting from `2.0.0`, `label-conflict` action does not produce output anymore.
+
+### Changed
+- Greatly reduced the number of GraphQL requests.
+  GraphQL requests for pull requests whose base branch is the working branch are now unified
+  into a single GraphQL request. 
+
+## [1.0.0]
+Initial release.

--- a/label-conflict/action.yml
+++ b/label-conflict/action.yml
@@ -21,9 +21,6 @@ inputs:
     description: "Comment to add when conflict is detected. Supports Markdown"
   commentToAddOnClean:
     description: "Comment to add when conflict is resolved. Supports Markdown"
-outputs:
-  conflictStatus:
-    description: "Key-Value pairs. Key: pull request number. Value: boolean(if true, then the corresponding PR has conflict)"
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/label-conflict/package.json
+++ b/label-conflict/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.0",
   "scripts": {
     "build": "ncc build src/main.ts --license LICENSE.txt",
     "lint": "eslint ."

--- a/label-conflict/src/env.ts
+++ b/label-conflict/src/env.ts
@@ -1,4 +1,3 @@
-export const conflictStatusOutputKey = "conflictStatus";
 export const commonErrorDetailedMessage = "Workflows can't access secrets and have read-only access to upstream when they are triggered by a pull request from a fork, [more information](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token)";
 export const eventName = process.env.GITHUB_EVENT_NAME;
 export const github_ref = process.env.GITHUB_REF || "";

--- a/label-conflict/src/label.ts
+++ b/label-conflict/src/label.ts
@@ -23,7 +23,7 @@ export async function addLabel(
 ): Promise<boolean> {
   const hasLabel = pr.labels.nodes.some(label => label.name === labelName);
   if(hasLabel){
-    core.info(`  [Skip] PR#${pr.number} already has label '${labelName}'. No need to add.`);
+    core.info(`[Skip] PR#${pr.number} already has label '${labelName}'. No need to add.`);
     return false;
   }
   
@@ -36,7 +36,7 @@ export async function addLabel(
     })
     .then(
       () => {
-        core.info(`  [Success] Added label "${labelName}" to PR#${pr.number}`);
+        core.info(`[Success] Added label "${labelName}" to PR#${pr.number}`);
         return true;
       },
       (error: RestErrorResponse) => {
@@ -57,7 +57,7 @@ export async function removeLabel(
 ): Promise<boolean> {
   const hasLabel = pr.labels.nodes.some(label => label.name === labelName);
   if(!hasLabel){
-    core.info(`  [Skip] PR#${pr.number} does not have label '${labelName}'. No need to remove.`);
+    core.info(`[Skip] PR#${pr.number} does not have label '${labelName}'. No need to remove.`);
     return false;
   }
   
@@ -75,12 +75,12 @@ export async function removeLabel(
       },
       (error: RestErrorResponse) => {
         if(isMissingPermission(error) && ignorePermissionError){
-          core.warning(`  [Failure] Could not remove label "${labelName}" for PR#${pr.number}: ${commonErrorDetailedMessage}`);
+          core.warning(`[Failure] Could not remove label "${labelName}" for PR#${pr.number}: ${commonErrorDetailedMessage}`);
           return false;
         }
         else if(error.status === 404){
           core.info(
-            `  [Skip] On #${pr.number} label "${labelName}" doesn't need to be removed since it doesn't exist on that issue.`
+            `[Skip] On #${pr.number} label "${labelName}" doesn't need to be removed since it doesn't exist on that issue.`
           );
           return false;
         }
@@ -105,12 +105,12 @@ export async function addComment(
     body: comment,
   }).then(
     () => {
-      core.info(`  [Success] Created a comment for PR#${pr.number}`);
+      core.info(`[Success] Created a comment for PR#${pr.number}`);
       return;
     },
     (error: RestErrorResponse) => {
       if(isMissingPermission(error) && ignorePermissionError){
-        core.warning(`  [Failure] Couldn't add comment to PR#${pr.number}: ${commonErrorDetailedMessage}`);
+        core.warning(`[Failure] Couldn't add comment to PR#${pr.number}: ${commonErrorDetailedMessage}`);
         return;
       }
       
@@ -130,14 +130,19 @@ export async function updateLabel(
 ){
   core.debug(JSON.stringify(pr, null, 2));
   
-  const log = (message: string) => {
-    core.info(`${message} for PR#${pr.number}`);
+  const log = (message: string, debug?: boolean) => {
+    if(debug){
+      core.debug(`${message} for PR#${pr.number}`);
+    }
+    else{
+      core.info(`${message} for PR#${pr.number}`);
+    }
   };
   
   switch (pr.mergeable) {
     case "CONFLICTING": {
       const removeLabelInfo = labelToRemoveOnConflict ? `, removing label "${labelToRemoveOnConflict}"` : "";
-      log(`  Adding label "${labelToAddOnConflict}"` + removeLabelInfo);
+      log(`Adding label "${labelToAddOnConflict}"` + removeLabelInfo, true);
       
       // for labels PRs and issues are the same
       const tasks: Array<Promise<boolean>> = [addLabel(labelToAddOnConflict, pr, client)];
@@ -154,7 +159,7 @@ export async function updateLabel(
       break;
     }
     case "MERGEABLE": {
-      log(`  Removing label "${labelToAddOnConflict}"`);
+      log(`Removing label "${labelToAddOnConflict}"`, true);
       
       const removedDirtyLabel = await removeLabel(
         labelToAddOnConflict,
@@ -173,7 +178,7 @@ export async function updateLabel(
       break;
     }
     case "UNKNOWN":
-      log("  Encountered a pull request whose mergeable status is UNKNOWN. Skipping.");
+      log("Encountered a pull request whose mergeable status is UNKNOWN. Skipping.");
       break;
     default:
       throw new TypeError(`unhandled mergeable state '${pr.mergeable}'`);

--- a/label-conflict/src/main.ts
+++ b/label-conflict/src/main.ts
@@ -6,7 +6,6 @@ import {
   github_baseRef,
   github_headRef,
   github_ref,
-  conflictStatusOutputKey,
 } from "./env";
 import {
   commentToAddOnClean,
@@ -27,7 +26,6 @@ async function main() {
     && eventName !== "workflow_dispatch"
   ){
     core.info(`Skipping conflict check as the event(${eventName}) is not a target`);
-    core.setOutput(conflictStatusOutputKey, {});
     return;
   }
   
@@ -48,14 +46,13 @@ async function main() {
   else{
     // When pushing a tag, do nothing.
     core.info("No action taken when pushing a tag");
-    core.setOutput(conflictStatusOutputKey, {});
     return;
   }
   core.info(`Checking conflicts on this branch and branches whose target branch is: ${currentRef}`)
   
   const client = github.getOctokit(secretToken);
   
-  const conflictStatus = await checkConflict({
+  await checkConflict({
     currentRef,
     client,
     commentToAddOnClean,
@@ -65,8 +62,6 @@ async function main() {
     retryIntervalSec,
     retryMax,
   });
-  
-  core.setOutput(conflictStatusOutputKey, conflictStatus);
 }
 
 main().catch((error) => {

--- a/label-conflict/src/query.ts
+++ b/label-conflict/src/query.ts
@@ -82,12 +82,14 @@ export async function postOpenPullRequestsQuery(
     throw err;
   };
   
-  core.info("Posting GraphQL request");
-  core.info(JSON.stringify(requestParams, null, 2));
+  const queryId = params.searchRefType === "currentBranch" ?
+    `headRef=${requestParams.headRefName}` : `baseRef=${requestParams.baseRefName}`;
+  core.info("Posting GraphQL request for " + queryId);
+  core.debug(JSON.stringify(requestParams, null, 2));
   start = Date.now();
   let response = await client.graphql<OpenPullRequestsResponse>(OpenPullRequestsQuery, requestParams)
     .catch(onRejection);
-  core.info(`Request took ${Date.now() - start} ms`);
+  core.info(`Request took ${Date.now() - start} ms for ${queryId}`);
   
   if(!response){
     return [];
@@ -103,7 +105,7 @@ export async function postOpenPullRequestsQuery(
     });
   }
   
-  core.info(`Found ${response.repository.pullRequests.nodes.length} PRs`);
+  core.info(`Found ${response.repository.pullRequests.nodes.length} PRs for ${queryId}`);
   
   let retVal = response.repository.pullRequests.nodes;
   


### PR DESCRIPTION
# Changelog
- Updated `label-conflict` action
  - Removed `core.setOutput()` because it was deprecated
    (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)  
    Starting from `label-conflict@2.0.0`, the action does not produce output anymore.
  - Greatly reduced the number of GraphQL requests.
  GraphQL requests for pull requests whose base branch is the working branch are now unified
  into a single GraphQL request. 

![image](https://user-images.githubusercontent.com/84098616/205351099-51c1d5f0-475d-4aed-b8a9-ea9fcbd01624.png)

![image](https://user-images.githubusercontent.com/84098616/205351190-27726bc3-2872-4100-bc7a-723bbb0e8a93.png)

![image](https://user-images.githubusercontent.com/84098616/205351877-c8b44016-2b59-426d-96d9-ad7aee556916.png)
