### PR TITLE
Fixed `label-conflict` action sleeps at incorrect place

### DIFF
--- a/label-conflict/CHANGELOG.md
+++ b/label-conflict/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.0.1]
+### Fixed
+- Fixed incorrect retry sleep location.  
+  Previous flow:  
+  (0) Send GraphQL queries to fetch PR's conflict status  
+  (Starting retry loop from this point)  
+  (1) Update label for PRs whose conflict status are returned  
+  (2) Send GraphQL queries for PRs whose conflict status are still unknown  
+  (3) Sleep  
+  (4) Go to `(1)`  
+
+  As you might notice, "Sleep" should be between `(1)` and `(2)`
+
 ## [2.0.0]
 ### Breaking change
 - Removed `core.setOutput()` because it was deprecated

--- a/label-conflict/dist/index.js
+++ b/label-conflict/dist/index.js
@@ -9844,13 +9844,15 @@ function checkConflict(context) {
                 core.warning(`Retry count reached a threshold(${retryMax})`);
                 break;
             }
-            let checkConflictBetweenParentAndThisBranch = null;
-            let checkConflictBetweenThisAndChildBranches = null;
-            // prsOfThisBranchUnknown.length should be 0 or 1.
             if (prsOfThisBranchUnknown.length > 1) {
                 throw new Error(`Multiple base branches have been reported for a single branch(${currentRef})`);
             }
-            else if (prsOfThisBranchUnknown.length === 1) {
+            core.info(`Sleeping ${retryIntervalSec} sec`);
+            yield sleep(retryIntervalSec);
+            let checkConflictBetweenParentAndThisBranch = null;
+            let checkConflictBetweenThisAndChildBranches = null;
+            // prsOfThisBranchUnknown.length should be 0 or 1.
+            if (prsOfThisBranchUnknown.length === 1) {
                 const pr = prsOfThisBranchUnknown[0];
                 core.info(`Searching conflict between base branch and this branch(${currentRef}) if base branch exists`);
                 checkConflictBetweenParentAndThisBranch = (0, query_1.postOpenPullRequestsQuery)(client, {
@@ -9908,8 +9910,6 @@ function checkConflict(context) {
                 }
             }
             core.info(`Number of PRs whose mergeable status is UNKNOWN: ${prsOfThisBranchUnknown.length} + ${prsOfChildBranchUnknown.length}`);
-            core.info(`Sleeping ${retryIntervalSec} sec`);
-            yield sleep(retryIntervalSec);
             currentTry++;
         }
         yield Promise.all(labelTasks);

--- a/label-conflict/package.json
+++ b/label-conflict/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "build": "ncc build src/main.ts --license LICENSE.txt",
     "lint": "eslint ."

--- a/label-conflict/src/lib.ts
+++ b/label-conflict/src/lib.ts
@@ -118,15 +118,18 @@ export async function checkConflict(context: CheckConflictContext): Promise<Reco
       core.warning(`Retry count reached a threshold(${retryMax})`);
       break;
     }
+    if(prsOfThisBranchUnknown.length > 1){
+      throw new Error(`Multiple base branches have been reported for a single branch(${currentRef})`);
+    }
   
+    core.info(`Sleeping ${retryIntervalSec} sec`);
+    await sleep(retryIntervalSec);
+    
     let checkConflictBetweenParentAndThisBranch: Promise<PullRequestsNode[]>|null = null;
     let checkConflictBetweenThisAndChildBranches: Promise<PullRequestsNode[]>|null = null;
   
     // prsOfThisBranchUnknown.length should be 0 or 1.
-    if(prsOfThisBranchUnknown.length > 1){
-      throw new Error(`Multiple base branches have been reported for a single branch(${currentRef})`);
-    }
-    else if(prsOfThisBranchUnknown.length === 1){
+    if(prsOfThisBranchUnknown.length === 1){
       const pr = prsOfThisBranchUnknown[0];
       core.info(`Searching conflict between base branch and this branch(${currentRef}) if base branch exists`);
   
@@ -197,8 +200,6 @@ export async function checkConflict(context: CheckConflictContext): Promise<Reco
       `Number of PRs whose mergeable status is UNKNOWN: ${prsOfThisBranchUnknown.length} + ${prsOfChildBranchUnknown.length}`
     );
     
-    core.info(`Sleeping ${retryIntervalSec} sec`);
-    await sleep(retryIntervalSec);
     currentTry++;
   }
   


### PR DESCRIPTION
Current flow:
0. Send GraphQL queries to fetch PR's conflict status
(Starting loop from this point)
1. Update label for PRs whose conflict status are returned
2. Send GraphQL queries for PRs whose conflict status are unknown
3. Sleep
4. Go to `1.`

The location of sleep above should be between `1.` and `2.`