### PR TITLE
[label-conflict] Fix for forked branch

### DIFF
--- a/label-conflict/dist/index.js
+++ b/label-conflict/dist/index.js
@@ -9767,10 +9767,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.checkConflict = exports.refIsTag = exports.isPullRequestBranch = exports.getBranchName = void 0;
-const github = __importStar(__nccwpck_require__(5438));
 const core = __importStar(__nccwpck_require__(2186));
 const query_1 = __nccwpck_require__(3709);
 const label_1 = __nccwpck_require__(2008);
+const github = __importStar(__nccwpck_require__(5438));
 function getBranchName(ref) {
     return ref.replace(/^refs\/heads\//, "");
 }
@@ -9794,23 +9794,34 @@ function sleep(sec) {
 function checkConflict(context) {
     return __awaiter(this, void 0, void 0, function* () {
         const { currentRef, client, commentToAddOnClean, commentToAddOnConflict, labelToAddOnConflict, labelToRemoveOnConflict, retryIntervalSec, retryMax, } = context;
-        core.info(`Searching conflict between base branch and this branch(${currentRef}) if base branch exists`);
+        const repo = github.context.repo;
+        // `triggeringHead` is used to tell difference whether current running action is triggered by
+        // a branch on original repository or forked repository.
+        let triggeringHead;
+        if (github.context.payload.pull_request) {
+            const head = github.context.payload.pull_request.head;
+            triggeringHead = { login: head.repo.owner.login, ref: head.ref };
+        }
+        else {
+            triggeringHead = { login: repo.owner, ref: currentRef };
+        }
+        core.info(`>> Searching conflict between this branch(${currentRef}) and its base branch if the base branch exists`);
         // If pushing to a non-PR branch (main, master, ...), this returns empty array.
         let prsOfThisBranch = yield (0, query_1.postOpenPullRequestsQuery)(client, {
             refName: currentRef,
             searchRefType: "currentBranch",
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
+            repo,
+            triggeringHead,
         });
         if (prsOfThisBranch.length <= 0) {
             core.info(`No base branch for ${currentRef} was found.`);
         }
-        core.info(`Searching conflict between this branch(${currentRef}) and branches which target this branch`);
+        core.info(`>> Searching conflict between this branch(${currentRef}) and branches which target this branch`);
         let prsOfChildBranch = yield (0, query_1.postOpenPullRequestsQuery)(client, {
             refName: currentRef,
             searchRefType: "baseBranch",
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
+            repo,
+            triggeringHead,
         });
         if (prsOfThisBranch.length === 0 && prsOfChildBranch.length === 0) {
             core.warning("Found no pull requests associated with this branch");
@@ -9827,7 +9838,7 @@ function checkConflict(context) {
         const finishedPRs = new Set();
         let currentTry = 0;
         while ((prsOfThisBranch.length + prsOfChildBranch.length + prsOfThisBranchUnknown.length + prsOfChildBranchUnknown.length) > 0) {
-            core.info(`Retry loop #${currentTry}`);
+            core.info(`>> Retry loop #${currentTry}`);
             core.info(`There are ${prsOfThisBranch.length + prsOfChildBranch.length} PRs to update labels`);
             const prsToUpdateLabel = [].concat(prsOfThisBranch, prsOfChildBranch);
             for (let i = 0; i < prsToUpdateLabel.length; i++) {
@@ -9847,28 +9858,28 @@ function checkConflict(context) {
             if (prsOfThisBranchUnknown.length > 1) {
                 throw new Error(`Multiple base branches have been reported for a single branch(${currentRef})`);
             }
-            core.info(`Sleeping ${retryIntervalSec} sec`);
+            core.info(`>> Sleeping ${retryIntervalSec} sec`);
             yield sleep(retryIntervalSec);
             let checkConflictBetweenParentAndThisBranch = null;
             let checkConflictBetweenThisAndChildBranches = null;
             // prsOfThisBranchUnknown.length should be 0 or 1.
             if (prsOfThisBranchUnknown.length === 1) {
                 const pr = prsOfThisBranchUnknown[0];
-                core.info(`Searching conflict between base branch and this branch(${currentRef}) if base branch exists`);
+                core.info(`>> Searching conflict between this branch(${pr.headRefName}) and its base branch if the base branch exists`);
                 checkConflictBetweenParentAndThisBranch = (0, query_1.postOpenPullRequestsQuery)(client, {
                     refName: pr.headRefName,
                     searchRefType: "currentBranch",
-                    owner: github.context.repo.owner,
-                    repo: github.context.repo.repo,
+                    repo,
+                    triggeringHead,
                 });
             }
             if (prsOfChildBranchUnknown.length > 0) {
-                core.info(`Searching conflict between this branch(${currentRef}) and branches which target this branch`);
+                core.info(`>> Searching conflict between this branch(${currentRef}) and branches which target this branch`);
                 checkConflictBetweenThisAndChildBranches = (0, query_1.postOpenPullRequestsQuery)(client, {
                     refName: currentRef,
                     searchRefType: "baseBranch",
-                    owner: github.context.repo.owner,
-                    repo: github.context.repo.repo,
+                    repo,
+                    triggeringHead,
                 });
             }
             prsOfThisBranch = [];
@@ -9977,6 +9988,9 @@ const input_1 = __nccwpck_require__(6747);
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         core.info(`Event: ${env_1.eventName}`);
+        core.info(`GITHUB_REF: ${env_1.github_ref}`);
+        core.info(`GITHUB_BASE_REF: ${env_1.github_baseRef}`);
+        core.info(`GITHUB_HEAD_REF: ${env_1.github_headRef}`);
         if (env_1.eventName !== "push"
             && env_1.eventName !== "pull_request"
             && env_1.eventName !== "pull_request_target"
@@ -10002,7 +10016,6 @@ function main() {
             core.info("No action taken when pushing a tag");
             return;
         }
-        core.info(`Checking conflicts on this branch and branches whose target branch is: ${currentRef}`);
         const client = github.getOctokit(input_1.secretToken);
         yield (0, lib_1.checkConflict)({
             currentRef,
@@ -10095,11 +10108,15 @@ query openPullRequests($owner: String!, $repo: String!, $after: String, $baseRef
   `;
 function postOpenPullRequestsQuery(client, params) {
     return __awaiter(this, void 0, void 0, function* () {
+        const { repo, triggeringHead } = params;
+        const isTriggeringRef = (login, headRefName) => {
+            return login === triggeringHead.login && headRefName === triggeringHead.ref;
+        };
         const requestParams = {
             headRefName: params.searchRefType === "currentBranch" ? params.refName : undefined,
             baseRefName: params.searchRefType === "baseBranch" ? params.refName : undefined,
-            owner: params.owner,
-            repo: params.repo,
+            owner: repo.owner,
+            repo: repo.repo,
         };
         let start = Date.now();
         const onRejection = (err) => {
@@ -10118,15 +10135,34 @@ function postOpenPullRequestsQuery(client, params) {
         if (!response) {
             return [];
         }
-        if (params.searchRefType === "currentBranch") {
-            // This eliminates external branches whose headRefName is the same as `param.refName`.
-            // We aren't interested in conflicts between external branch and branches whose target is the external branch.
-            // By the code below, pullRequests with branches whose owner does not match the pullRequest repository owner
-            // will be eliminated.
-            response.repository.pullRequests.nodes = response.repository.pullRequests.nodes.filter(n => {
-                return n.headRepository && n.headRepository.owner.login === requestParams.owner;
-            });
-        }
+        // When searching PRs by headRefName, usually it returns only 1 PR.
+        // But there are cases where unintended PRs are returned because of the same branch name.
+        // i.e. When a user wants to check conflict for a PR whose headRef is `main`,
+        // it's possible that the GraphQL query returns 2 branches with the same name but from different repositories
+        // (For example, OriginalRepos:main and ForkedRepos:main).
+        // The code below will eliminate non-eligible PRs.
+        const filterPullRequests = (nodes) => {
+            if (params.searchRefType === "currentBranch") {
+                const prevLen = nodes.length;
+                const prNodes = nodes.filter(n => {
+                    if (!n.headRepository) {
+                        // Usually this may not happen.
+                        return true;
+                    }
+                    if (!isTriggeringRef(n.headRepository.owner.login, n.headRefName)) {
+                        core.info(`PR#${n.number} from ${n.headRepository.owner.login}:${n.headRefName} is filtered out.`);
+                        return false;
+                    }
+                    return true;
+                });
+                if (prevLen > prNodes.length) {
+                    core.info(`The eligible branch for the target PR is ${triggeringHead.login}:${triggeringHead.ref}`);
+                }
+                return prNodes;
+            }
+            return nodes;
+        };
+        response.repository.pullRequests.nodes = filterPullRequests(response.repository.pullRequests.nodes);
         core.info(`Found ${response.repository.pullRequests.nodes.length} PRs for ${queryId}`);
         let retVal = response.repository.pullRequests.nodes;
         while (response.repository.pullRequests.pageInfo.hasNextPage) {
@@ -10138,11 +10174,7 @@ function postOpenPullRequestsQuery(client, params) {
             if (!response) {
                 return [];
             }
-            if (params.searchRefType === "currentBranch") {
-                response.repository.pullRequests.nodes = response.repository.pullRequests.nodes.filter(n => {
-                    return n.headRepository && n.headRepository.owner.login === requestParams.owner;
-                });
-            }
+            response.repository.pullRequests.nodes = filterPullRequests(response.repository.pullRequests.nodes);
             core.info(`Found ${response.repository.pullRequests.nodes.length} PRs`);
             retVal = retVal.concat(response.repository.pullRequests.nodes);
         }

--- a/label-conflict/src/main.ts
+++ b/label-conflict/src/main.ts
@@ -19,6 +19,9 @@ import {
 
 async function main() {
   core.info(`Event: ${eventName}`);
+  core.info(`GITHUB_REF: ${github_ref}`);
+  core.info(`GITHUB_BASE_REF: ${github_baseRef}`);
+  core.info(`GITHUB_HEAD_REF: ${github_headRef}`);
   
   if(eventName !== "push"
     && eventName !== "pull_request"
@@ -48,7 +51,6 @@ async function main() {
     core.info("No action taken when pushing a tag");
     return;
   }
-  core.info(`Checking conflicts on this branch and branches whose target branch is: ${currentRef}`)
   
   const client = github.getOctokit(secretToken);
   


### PR DESCRIPTION
# PR for label-conflict action

## Issue
`label-conflict` action does not recognize pull requests pushed from forked branch with warning:
`Found no pull requests associated with this branch`.
This is because the `label-conflict` action searches for conflicting pull requests by branch/tag name on the original repository where forked branch does not exist. (it exists in forked repository)

(Searching pull requests by branch/tag name is a restrinction by GitHub's GraphQL Query)
https://docs.github.com/en/graphql/reference/objects#repository
* Scroll down to `pullRequests` section. You'll find that there are `headRefName`, `baseRefName` but not 'repository owner' for search conditions.

## Changelog
When searching for a branch by repository name, now it filters out branches whose repository owner does not match the branch owner which triggers the action.
For example  
1) A user named `Some-User` wants to push a forked branch `Some-User:main` into  `Chia-Network:main`.
2) The action is triggered on `pull_request_target` event with `synchronize` type
3) The action queries a PR whose branch name is `main`. (If we can specify like `Some-User:main`, we don't have this problem)
4) GitHub's GraphQL query returns PRs for `Some-User:main` and `Chia-Network:main`
5) The branch owner who triggers the action is `Some-User` so `Chia-Network:main` is filtered out.
6) Conflicts around `Some-User:main` is checked.

## Test
https://github.com/ChiaMineJP/test-action/actions/runs/3715009949/jobs/6299658511
![image](https://user-images.githubusercontent.com/84098616/208151401-5111babf-4be1-48a6-9569-f5282b5ba827.png)
