### PR TITLE
Added `ignoreRetryTimeout` option

### DIFF
--- a/label-conflict/CHANGELOG.md
+++ b/label-conflict/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [2.1.0]
+## [3.0.0]
 ### Added
 - Added `ignoreRetryTimeout` option, which indicates whether to mark the action success when unknown
-  PRs still exist after all retry. (Default to `false` so there's no behavior change when you update from version `2.0.1`)
+  PRs still exist after all retry.  
+  (Default to `true` so there's breaking change if you update from the previous versions)
 
 ## [2.0.1]
 ### Fixed

--- a/label-conflict/CHANGELOG.md
+++ b/label-conflict/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.0]
+### Added
+- Added `ignoreRetryTimeout` option, which indicates whether to mark the action success when unknown
+  PRs still exist after all retry. (Default to `false` so there's no behavior change when you update from version `2.0.1`)
+
 ## [2.0.1]
 ### Fixed
 - Fixed incorrect retry sleep location.  

--- a/label-conflict/README.md
+++ b/label-conflict/README.md
@@ -102,7 +102,7 @@ resulting in a failure to update tags.
 
 Boolean. Whether to mark the action success when unknown PRs still exist after all retry.
 
-**Default**: false
+**Default**: true
 
 ### `commentToAddOnConflict`
 

--- a/label-conflict/README.md
+++ b/label-conflict/README.md
@@ -98,6 +98,12 @@ resulting in a failure to update tags.
 
 **Default**: false
 
+### `ignoreRetryTimeout`
+
+Boolean. Whether to mark the action success when unknown PRs still exist after all retry.
+
+**Default**: false
+
 ### `commentToAddOnConflict`
 
 Comment to add when conflict is detected. Supports Markdown

--- a/label-conflict/action.yml
+++ b/label-conflict/action.yml
@@ -17,6 +17,8 @@ inputs:
     default: "5"
   ignorePermissionError:
     description: "Boolean. Whether to continue or fail when the provided token is missing permissions. By default pull requests from a fork do not have access to secrets and get a read only github token, resulting in a failure to update tags."
+  ignoreRetryTimeout:
+    description: "Boolean. Whether to mark the action success when unknown PRs still exist after all retry"
   commentToAddOnConflict:
     description: "Comment to add when conflict is detected. Supports Markdown"
   commentToAddOnClean:

--- a/label-conflict/action.yml
+++ b/label-conflict/action.yml
@@ -19,6 +19,7 @@ inputs:
     description: "Boolean. Whether to continue or fail when the provided token is missing permissions. By default pull requests from a fork do not have access to secrets and get a read only github token, resulting in a failure to update tags."
   ignoreRetryTimeout:
     description: "Boolean. Whether to mark the action success when unknown PRs still exist after all retry"
+    default: "true"
   commentToAddOnConflict:
     description: "Comment to add when conflict is detected. Supports Markdown"
   commentToAddOnClean:

--- a/label-conflict/dist/index.js
+++ b/label-conflict/dist/index.js
@@ -9542,7 +9542,7 @@ exports.retryMax = parseInt(core.getInput("retryMax"), 10);
 exports.commentToAddOnConflict = core.getInput("commentToAddOnConflict");
 exports.commentToAddOnClean = core.getInput("commentToAddOnClean");
 exports.ignorePermissionError = core.getInput("ignorePermissionError") === "true"; // Default: false
-exports.ignoreRetryTimeout = core.getInput("ignoreRetryTimeout") === "true"; // Default: false
+exports.ignoreRetryTimeout = core.getInput("ignoreRetryTimeout") !== "false"; // Default: true
 
 
 /***/ }),

--- a/label-conflict/dist/index.js
+++ b/label-conflict/dist/index.js
@@ -9532,7 +9532,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ignorePermissionError = exports.commentToAddOnClean = exports.commentToAddOnConflict = exports.retryMax = exports.retryIntervalSec = exports.labelToRemoveOnConflict = exports.labelToAddOnConflict = exports.secretToken = void 0;
+exports.ignoreRetryTimeout = exports.ignorePermissionError = exports.commentToAddOnClean = exports.commentToAddOnConflict = exports.retryMax = exports.retryIntervalSec = exports.labelToRemoveOnConflict = exports.labelToAddOnConflict = exports.secretToken = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 exports.secretToken = core.getInput("secretToken", { required: true });
 exports.labelToAddOnConflict = core.getInput("labelToAddOnConflict", { required: true });
@@ -9542,6 +9542,7 @@ exports.retryMax = parseInt(core.getInput("retryMax"), 10);
 exports.commentToAddOnConflict = core.getInput("commentToAddOnConflict");
 exports.commentToAddOnClean = core.getInput("commentToAddOnClean");
 exports.ignorePermissionError = core.getInput("ignorePermissionError") === "true"; // Default: false
+exports.ignoreRetryTimeout = core.getInput("ignoreRetryTimeout") === "true"; // Default: false
 
 
 /***/ }),
@@ -9768,9 +9769,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.checkConflict = exports.refIsTag = exports.isPullRequestBranch = exports.getBranchName = void 0;
 const core = __importStar(__nccwpck_require__(2186));
+const github = __importStar(__nccwpck_require__(5438));
 const query_1 = __nccwpck_require__(3709);
 const label_1 = __nccwpck_require__(2008);
-const github = __importStar(__nccwpck_require__(5438));
+const input_1 = __nccwpck_require__(6747);
 function getBranchName(ref) {
     return ref.replace(/^refs\/heads\//, "");
 }
@@ -9932,7 +9934,9 @@ function checkConflict(context) {
                 const pr = prs[i];
                 core.info(`  #${pr.number} (${pr.title})`);
             }
-            throw new Error("Failed to check conflict");
+            if (!input_1.ignoreRetryTimeout) {
+                throw new Error("Failed to check conflict");
+            }
         }
         return conflictStatus;
     });

--- a/label-conflict/package.json
+++ b/label-conflict/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "private": true,
-  "version": "2.1.0",
+  "version": "3.0.0",
   "scripts": {
     "build": "ncc build src/main.ts --license LICENSE.txt",
     "lint": "eslint ."

--- a/label-conflict/package.json
+++ b/label-conflict/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.1.0",
   "scripts": {
     "build": "ncc build src/main.ts --license LICENSE.txt",
     "lint": "eslint ."

--- a/label-conflict/src/input.ts
+++ b/label-conflict/src/input.ts
@@ -8,4 +8,4 @@ export const retryMax = parseInt(core.getInput("retryMax"), 10);
 export const commentToAddOnConflict = core.getInput("commentToAddOnConflict");
 export const commentToAddOnClean = core.getInput("commentToAddOnClean");
 export const ignorePermissionError = core.getInput("ignorePermissionError") === "true"; // Default: false
-export const ignoreRetryTimeout = core.getInput("ignoreRetryTimeout") === "true"; // Default: false
+export const ignoreRetryTimeout = core.getInput("ignoreRetryTimeout") !== "false"; // Default: true

--- a/label-conflict/src/input.ts
+++ b/label-conflict/src/input.ts
@@ -8,3 +8,4 @@ export const retryMax = parseInt(core.getInput("retryMax"), 10);
 export const commentToAddOnConflict = core.getInput("commentToAddOnConflict");
 export const commentToAddOnClean = core.getInput("commentToAddOnClean");
 export const ignorePermissionError = core.getInput("ignorePermissionError") === "true"; // Default: false
+export const ignoreRetryTimeout = core.getInput("ignoreRetryTimeout") === "true"; // Default: false

--- a/label-conflict/src/lib.ts
+++ b/label-conflict/src/lib.ts
@@ -1,8 +1,9 @@
 import {getOctokit} from "@actions/github";
 import * as core from "@actions/core";
+import * as github from "@actions/github";
 import {GitHubContextPayloadPullRequest, postOpenPullRequestsQuery, PullRequestsNode} from "./query";
 import {updateLabel} from "./label";
-import * as github from "@actions/github";
+import {ignoreRetryTimeout} from "./input";
 
 export type Octokit = ReturnType<typeof getOctokit>;
 
@@ -223,7 +224,9 @@ export async function checkConflict(context: CheckConflictContext): Promise<Reco
       const pr = prs[i];
       core.info(`  #${pr.number} (${pr.title})`);
     }
-    throw new Error("Failed to check conflict");
+    if(!ignoreRetryTimeout){
+      throw new Error("Failed to check conflict");
+    }
   }
   
   return conflictStatus;


### PR DESCRIPTION
Added `ignoreRetryTimeout` option, which indicates whether to mark the action success when unknown
  PRs still exist after all retry. (Default to `false` so there's no behavior change when you update from version `2.0.1`)