### PR TITLE
cleanup the temp keychain used for macos signing

### DIFF
--- a/clean-workspace/action.yml
+++ b/clean-workspace/action.yml
@@ -3,7 +3,7 @@ description: "Cleans the current workspace before checking out code, to ensure a
 runs:
   using: "composite"
   steps:
-    - name: Install dependencies
+    - name: Clean Files
       run: |
         # This step needs both sudo and non-sudo versions of the same command in case this is run in a container
         # without sudo installed
@@ -12,4 +12,10 @@ runs:
         
         sudo rm -rf $HOME/.npm || true
         rm -rf $HOME/.npm || true
+      shell: sh
+    - name: Clean macOS Keychain
+      if: runner.os == 'macOS'
+      run: |
+        # relevant to https://github.com/Apple-Actions/import-codesign-certs
+        security delete-keychain signing_temp.keychain || true
       shell: sh


### PR DESCRIPTION
https://github.com/Chia-Network/Climate-Wallet/actions/runs/4704600840/jobs/8344373396?pr=18#step:8:10
```
/usr/bin/security create-keychain -p *** signing_temp.keychain
security: SecKeychainCreate signing_temp.keychain: A keychain with the same name already exists.
Error: The process '/usr/bin/security' failed with exit code 4[8](https://github.com/Chia-Network/Climate-Wallet/actions/runs/4704600840/jobs/8344373396?pr=18#step:8:9)
```

https://github.com/Chia-Network/chia-blockchain/blob/9b8cdd36daebf2efe8777c98e212e564f4cdd475/.github/workflows/build-macos-installers.yml#L104-L108
```yaml
      # This will be recreated in the next step
      # Done now and at the end of the workflow in case the last workflow fails, and this is still around
      - name: Delete keychain if it already exists
        run:
          security delete-keychain signing_temp.keychain || true
```

https://github.com/Chia-Network/chia-blockchain/blob/9b8cdd36daebf2efe8777c98e212e564f4cdd475/.github/workflows/build-macos-installers.yml#L285-L289
```yaml
      # We want to delete this no matter what happened in the previous steps (failures, success, etc)
      - name: Delete signing keychain
        if: always()
        run:
          security delete-keychain signing_temp.keychain || true
```