### PR TITLE
Upgraded Node.js runtime version to `20` from `16`

### DIFF
--- a/label-conflict/CHANGELOG.md
+++ b/label-conflict/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.1]
+### Changed
+- Upgraded Node.js runtime version to `20` from `16`.
+
 ## [3.0.0]
 ### Added
 - Added `ignoreRetryTimeout` option, which indicates whether to mark the action success when unknown

--- a/label-conflict/action.yml
+++ b/label-conflict/action.yml
@@ -25,7 +25,7 @@ inputs:
   commentToAddOnClean:
     description: "Comment to add when conflict is resolved. Supports Markdown"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 author: "Izumi Hoshino"
 branding:

--- a/label-conflict/package.json
+++ b/label-conflict/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "scripts": {
     "build": "ncc build src/main.ts --license LICENSE.txt",
     "lint": "eslint ."


### PR DESCRIPTION
Fixed for this:
[GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

