### PR TITLE
Update upstream setup-python action call to v5

### DIFF
--- a/setup-python/action.yml
+++ b/setup-python/action.yml
@@ -68,7 +68,7 @@ runs:
         echo "version-string=${SELECTED_PYTHON_VERSION}" | tee -a "${GITHUB_OUTPUT}"
 
     - name: Call upstream setup-python action
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       # Requires native m1 runner software, not x64 running via arch flags
       if: runner.arch != 'ARM64' && inputs.force-pyenv == 'false'
       with:


### PR DESCRIPTION
Addressing `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`