### PR TITLE
Add message Action and add custom audience support in JWT Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -416,6 +416,24 @@ updates:
       - "cmmarslender"
   # generated
   - package-ecosystem: "github-actions"
+    directory: "message"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    labels:
+      - dependencies
+      - github_actions
+    target-branch: "main"
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"
+    reviewers:
+      - "cmmarslender"
+  # generated
+  - package-ecosystem: "github-actions"
     directory: "poetry"
     # Check for updates once a week
     schedule:

--- a/github/jwt/action.yml
+++ b/github/jwt/action.yml
@@ -1,5 +1,10 @@
 name: "Gets JWT Token from GitHub"
 description: "Gets JWT token from github"
+inputs:
+  audience:
+    description: "The audience for the OIDC token request. If not specified, the token will be requested without an audience."
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -17,10 +22,17 @@ runs:
 
     - name: Get JWT from GitHub
       shell: sh
+      env:
+        AUDIENCE: ${{ inputs.audience }}
       run: |
+        REQUEST_URL="$ACTIONS_ID_TOKEN_REQUEST_URL"
+        if [ -n "$AUDIENCE" ]; then
+          REQUEST_URL="${REQUEST_URL}&audience=${AUDIENCE}"
+        fi
+
         i=1
         while [ "${i}" -le 5 ]; do
-          JWT_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value')
+          JWT_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$REQUEST_URL" | jq -r '.value')
           if [ -n "$JWT_TOKEN" ]; then
             echo "::add-mask::$JWT_TOKEN"
             echo "JWT_TOKEN=$JWT_TOKEN" >> "$GITHUB_ENV"

--- a/message/action.yml
+++ b/message/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Get GitHub JWT
-      uses: Chia-Network/actions/github/jwt@add-github-message-action
+      uses: Chia-Network/actions/github/jwt@main
       with:
         audience: ${{ inputs.receiver_url }}
 

--- a/message/action.yml
+++ b/message/action.yml
@@ -1,0 +1,46 @@
+name: "Send message via alert-receiver"
+description: "Gets a GitHub JWT and sends a message to the alert-receiver worker"
+inputs:
+  receiver_url:
+    description: "Base URL of the alert-receiver worker"
+    required: false
+    default: "https://alert-receiver.chiaops.com/"
+  receiver_route:
+    description: "The route to call on the receiver (appended to receiver_url)"
+    required: true
+  message:
+    description: "The message to send in the POST body"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Get GitHub JWT
+      uses: Chia-Network/actions/github/jwt@add-github-message-action
+      with:
+        audience: ${{ inputs.receiver_url }}
+
+    - name: Send message
+      shell: sh
+      env:
+        RECEIVER_URL: ${{ inputs.receiver_url }}
+        RECEIVER_ROUTE: ${{ inputs.receiver_route }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        BASE_URL="${RECEIVER_URL%/}"
+        ROUTE="${RECEIVER_ROUTE#/}"
+        FULL_URL="${BASE_URL}/${ROUTE}"
+
+        RESPONSE=$(curl -sS -w '\n%{http_code}' \
+          -X POST \
+          -H "Authorization: Bearer ${JWT_TOKEN}" \
+          -d "${MESSAGE}" \
+          "${FULL_URL}")
+        RESPONSE_CODE=$(echo "$RESPONSE" | tail -1)
+        RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+
+        echo "HTTP ${RESPONSE_CODE}: ${RESPONSE_BODY}"
+
+        if [ "$RESPONSE_CODE" != "200" ]; then
+          echo "Request failed"
+          exit 1
+        fi

--- a/message/readme.md
+++ b/message/readme.md
@@ -1,0 +1,41 @@
+# Message Action
+
+Sends a message to the alert-receiver worker using GitHub OIDC for authentication. Automatically obtains a JWT with the receiver URL as the audience, then POSTs the message to the specified route.
+
+## Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `receiver_url` | No | `https://alert-receiver.chiaops.com/` | Base URL of the alert-receiver worker |
+| `receiver_route` | Yes | | The route to call on the receiver (appended to `receiver_url`) |
+| `message` | Yes | | The message to send in the POST body |
+
+## Permissions
+
+The calling workflow must have `id-token: write` permission for the GitHub OIDC token request.
+
+```yaml
+permissions:
+  id-token: write
+```
+
+## Usage
+
+```yaml
+- name: Send message
+  uses: Chia-Network/actions/message@main
+  with:
+    receiver_route: teambottesting-github
+    message: "Build succeeded for ${{ github.repository }}"
+```
+
+With a custom receiver URL:
+
+```yaml
+- name: Send message
+  uses: Chia-Network/actions/message@main
+  with:
+    receiver_url: https://1.alert-receiver-dev.chiaops.com/
+    receiver_route: teambottesting-github
+    message: "Smoke test from deploy-dev workflow"
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new outbound HTTP action and changes how OIDC JWTs are requested (optional audience), which can affect authentication and external integrations if misconfigured.
> 
> **Overview**
> Adds a new composite GitHub Action (`message`) that mints a GitHub OIDC JWT and POSTs a caller-supplied message to an `alert-receiver` endpoint, failing the workflow on non-200 responses, with accompanying usage docs.
> 
> Enhances the existing `github/jwt` action to accept an optional `audience` input and include it in the OIDC token request URL, and updates Dependabot config to track `github-actions` updates for the new `message` directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb137c97ccdf70a590b3f6833fb0089ad7f7511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->