### PR TITLE
Add federated workload support to tailscale action

### DIFF
--- a/message/readme.md
+++ b/message/readme.md
@@ -4,11 +4,11 @@ Sends a message to the alert-receiver worker using GitHub OIDC for authenticatio
 
 ## Inputs
 
-| Name | Required | Default | Description |
-|------|----------|---------|-------------|
-| `receiver_url` | No | `https://alert-receiver.chiaops.com/` | Base URL of the alert-receiver worker |
-| `receiver_route` | Yes | | The route to call on the receiver (appended to `receiver_url`) |
-| `message` | Yes | | The message to send in the POST body |
+| Name             | Required | Default                               | Description                                                    |
+| ---------------- | -------- | ------------------------------------- | -------------------------------------------------------------- |
+| `receiver_url`   | No       | `https://alert-receiver.chiaops.com/` | Base URL of the alert-receiver worker                          |
+| `receiver_route` | Yes      |                                       | The route to call on the receiver (appended to `receiver_url`) |
+| `message`        | Yes      |                                       | The message to send in the POST body                           |
 
 ## Permissions
 

--- a/tailscale/action.yml
+++ b/tailscale/action.yml
@@ -2,13 +2,16 @@ name: "Connect Tailscale"
 description: "Wrapper around the official tailscale action to add support for containers and ssh connections"
 inputs:
   oauth-client-id:
-    description: "Your Tailscale OAuth Client ID."
+    description: "This is your Tailscale OAuth/OIDC Client ID."
     required: true
   oauth-secret:
-    description: "Your Tailscale OAuth Client Secret."
-    required: true
+    description: "If using an OAuth trust credential from Tailscale this is your Tailscale OAuth Client Secret."
+    required: false
+  oidc-audience:
+    description: "If using an OIDC trust credential from Tailscale this is your aud claim."
+    required: false
   tags:
-    description: "Comma separated list of Tags to be applied to nodes. The OAuth client must have permission to apply these tags."
+    description: "Comma separated list of Tags to be applied to nodes. The Tailscale trust credential must have permission to apply these tags."
     required: true
   args:
     description: "Optional additional arguments to `tailscale up`"
@@ -27,11 +30,38 @@ runs:
         ( command -v apk && apk add bash coreutils curl netcat-openbsd openssh-client sudo ) || true
         ( command -v apt-get && apt-get update && apt-get install -y curl netcat-openbsd openssh-client sudo ) || true
 
-    - name: Tailscale
+    - name: Validate Tailscale trust credential inputs
+      shell: sh
+      env:
+        OAUTH_SECRET: ${{ inputs.oauth-secret }}
+        OIDC_AUDIENCE: ${{ inputs.oidc-audience }}
+      run: |
+        if [ -n "$OAUTH_SECRET" ] && [ -n "$OIDC_AUDIENCE" ]; then
+          echo "::error::Provide either 'oauth-secret' or 'oidc-audience', not both."
+          exit 1
+        fi
+        if [ -z "$OAUTH_SECRET" ] && [ -z "$OIDC_AUDIENCE" ]; then
+          echo "::error::One of 'oauth-secret' or 'oidc-audience' must be provided."
+          exit 1
+        fi
+
+    - name: Tailscale (OAuth)
+      if: inputs.oauth-secret != ''
       uses: tailscale/github-action@v4
       with:
         oauth-client-id: ${{ inputs.oauth-client-id }}
         oauth-secret: ${{ inputs.oauth-secret }}
+        tags: ${{ inputs.tags }}
+        args: ${{ inputs.args }}
+        tailscaled-args: "--tun=userspace-networking --socks5-server=localhost:1055"
+        hostname: ${{ inputs.hostname }}
+
+    - name: Tailscale (OIDC)
+      if: inputs.oidc-audience != ''
+      uses: tailscale/github-action@v4
+      with:
+        oauth-client-id: ${{ inputs.oauth-client-id }}
+        audience: ${{ inputs.oidc-audience }}
         tags: ${{ inputs.tags }}
         args: ${{ inputs.args }}
         tailscaled-args: "--tun=userspace-networking --socks5-server=localhost:1055"

--- a/tailscale/readme.md
+++ b/tailscale/readme.md
@@ -1,6 +1,13 @@
 # Tailscale Wrapper w/ SSH Support
 
-Wrapper around `tailscale/github-action` that works w/ containers and sets up SSH support
+Wrapper around `tailscale/github-action` that works w/ containers and sets up SSH support.
+
+Either an OAuth trust credential (`oauth-secret`) or an OIDC / workload identity
+federation trust credential (`oidc-audience`) must be provided. Whichever
+credential is used must have the writable `auth_keys` scope and permission to
+apply the requested `tags`.
+
+## OAuth trust credential
 
 ```yaml
 - name: Tailscale
@@ -8,5 +15,24 @@ Wrapper around `tailscale/github-action` that works w/ containers and sets up SS
   with:
     oauth-client-id: ${{ env.TAILSCALE_CLIENT_ID }}
     oauth-secret: ${{ env.TAILSCALE_SECRET }}
+    tags: tag:ci
+```
+
+## OIDC / Workload identity federation
+
+Requires Tailscale `1.90.1` or later, and the `id-token: write` permission on
+the workflow so the action can request a JWT from GitHub:
+
+```yaml
+permissions:
+  id-token: write
+```
+
+```yaml
+- name: Tailscale
+  uses: chia-network/actions/tailscale@main
+  with:
+    oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+    oidc-audience: ${{ secrets.TS_AUDIENCE }}
     tags: tag:ci
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new authentication path and input validation to the Tailscale composite action; misconfiguration could break CI connectivity, but changes are localized to the action wrapper and docs.
> 
> **Overview**
> Adds **OIDC / workload identity federation** support to the `tailscale` composite action by introducing an `oidc-audience` input and routing to `tailscale/github-action@v4` with `audience` when provided.
> 
> The action now enforces that *exactly one* of `oauth-secret` (OAuth trust credential) or `oidc-audience` is set, and updates documentation to include OIDC setup requirements and examples. Separately, the `message` action README table formatting is cleaned up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a858f1be66962b720f9e1fa1176f4f18321355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->