### PR TITLE
fix(tailscale): support non-root runners

### DIFF
--- a/tailscale/action.yml
+++ b/tailscale/action.yml
@@ -27,8 +27,14 @@ runs:
     - name: Install deps
       shell: sh
       run: |
-        ( command -v apk && apk add bash coreutils curl netcat-openbsd openssh-client sudo ) || true
-        ( command -v apt-get && apt-get update && apt-get install -y curl netcat-openbsd openssh-client sudo ) || true
+        # If running as root, then don't use sudo
+        if [ "$(id -u)" -eq 0 ]; then
+            SUDO=""
+        else
+            SUDO=$(command -v sudo || echo "")
+        fi
+        ( command -v apk && ${SUDO} apk add bash coreutils curl netcat-openbsd openssh-client sudo ) || true
+        ( command -v apt-get && ${SUDO} apt-get update && ${SUDO} apt-get install -y curl netcat-openbsd openssh-client sudo ) || true
 
     - name: Validate Tailscale trust credential inputs
       shell: sh
@@ -82,4 +88,14 @@ runs:
     - name: Fix /etc/passwd file for alternate $HOME path
       shell: sh
       run: |
-        sed -i "s~root:/root~root:$HOME~g" /etc/passwd
+        # If running as root, then don't use sudo
+        if [ "$(id -u)" -eq 0 ]; then
+            SUDO=""
+        else
+            SUDO=$(command -v sudo || echo "")
+        fi
+        CURRENT_USER=$(id -un)
+        CURRENT_HOME_IN_PASSWD=$(getent passwd "$CURRENT_USER" | cut -d: -f6)
+        if [ "$CURRENT_HOME_IN_PASSWD" != "$HOME" ]; then
+            ${SUDO} sed -i "s~${CURRENT_USER}:${CURRENT_HOME_IN_PASSWD}~${CURRENT_USER}:${HOME}~g" /etc/passwd
+        fi


### PR DESCRIPTION
## Summary

- Add `sudo` detection to the `Install deps` step so `apk`/`apt-get` installs work on non-root runners (e.g. `ubuntu-latest`, Blacksmith)
- Fix the `/etc/passwd` step to use `sudo` when needed, and update the *current user's* home dir entry dynamically (via `getent passwd`) rather than hardcoding `root:/root` — which never matched on non-root runners anyway

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dependency installation and `/etc/passwd` rewriting in the composite action, but could impact runner setup if `sudo`/`sed` behavior differs across environments.
> 
> **Overview**
> Improves the `tailscale` composite action to work on non-root runners by **detecting when `sudo` is needed** (or omitting it when already root) for package installs via `apk`/`apt-get`.
> 
> Updates the `/etc/passwd` fixup step to **modify the current user’s home directory entry dynamically** (via `getent`) and only when it mismatches `$HOME`, using `sudo` when required instead of hardcoding a `root:/root` replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511540de187350221f68eafb1b5e482e745d21a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->