### PR TITLE
Allow opting out of userspace networking

### DIFF
--- a/tailscale/action.yml
+++ b/tailscale/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Fixed hostname to use."
     required: false
     default: ""
+  userspace-networking:
+    description: "Use userspace networking mode (--tun=userspace-networking). Required on runners that don't support TUN devices. When false, kernel TUN is used and traffic routes normally."
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -59,7 +63,7 @@ runs:
         oauth-secret: ${{ inputs.oauth-secret }}
         tags: ${{ inputs.tags }}
         args: ${{ inputs.args }}
-        tailscaled-args: "--tun=userspace-networking --socks5-server=localhost:1055"
+        tailscaled-args: ${{ inputs.userspace-networking == 'true' && '--tun=userspace-networking --socks5-server=localhost:1055' || '' }}
         hostname: ${{ inputs.hostname }}
 
     - name: Tailscale (OIDC)
@@ -70,10 +74,11 @@ runs:
         audience: ${{ inputs.oidc-audience }}
         tags: ${{ inputs.tags }}
         args: ${{ inputs.args }}
-        tailscaled-args: "--tun=userspace-networking --socks5-server=localhost:1055"
+        tailscaled-args: ${{ inputs.userspace-networking == 'true' && '--tun=userspace-networking --socks5-server=localhost:1055' || '' }}
         hostname: ${{ inputs.hostname }}
 
     - name: Add SSH Proxy Config
+      if: inputs.userspace-networking == 'true'
       shell: sh
       run: |
         mkdir -p ~/.ssh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new input that changes how Tailscale networking is initialized and conditionally disables the SOCKS/SSH proxy path; misconfiguration could break connectivity in workflows that relied on userspace mode.
> 
> **Overview**
> Adds a new `userspace-networking` input (default `true`) to allow opting out of `--tun=userspace-networking` when runners support kernel TUN.
> 
> When disabled, the action no longer passes userspace `tailscaled-args` (including the local SOCKS5 server) and skips the SSH proxy config step, allowing traffic to route normally via kernel networking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8517875b26439a67bcf0ef47964c21db4f78e318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->