### PR TITLE
Make cache-pip restore resilient to transient cache failures

### DIFF
--- a/cache-pip/action.yml
+++ b/cache-pip/action.yml
@@ -14,6 +14,17 @@ inputs:
       - "setuptools"
       - "poetry"
 
+outputs:
+  cache-hit:
+    description: Whether the primary cache key was restored
+    value: ${{ steps.cache-restore-result.outputs.cache-hit }}
+  cache-primary-key:
+    description: Cache key used for restore and save
+    value: ${{ steps.cache-restore-result.outputs.cache-primary-key }}
+  dir:
+    description: Local cache directory path
+    value: ${{ steps.create-directory.outputs.dir }}
+
 runs:
   using: "composite"
   steps:
@@ -25,8 +36,10 @@ runs:
       run: |
         python "${GITHUB_ACTION_PATH}/cache_pip.py" "${{ inputs.mode }}"
 
-    - name: Cache pip
-      uses: actions/cache@v5
+    - name: Restore pip cache
+      id: restore-pip-cache
+      uses: actions/cache/restore@v5
+      continue-on-error: true
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
       with:
@@ -35,7 +48,46 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ inputs.mode }}-
 
+    - name: Retry pip cache restore
+      id: retry-pip-cache
+      if: steps.restore-pip-cache.outcome == 'failure'
+      uses: actions/cache/restore@v5
+      continue-on-error: true
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
+      with:
+        path: ${{ steps.create-directory.outputs.dir }}
+        key: ${{ runner.os }}-${{ inputs.mode }}-${{ (inputs.mode == 'pip' && hashFiles('**/setup.py')) || (inputs.mode == 'poetry' && hashFiles('**/poetry.lock')) || 'unhandled_case' }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.mode }}-
+
+    - name: Set cache restore outputs
+      id: cache-restore-result
+      shell: bash
+      run: |
+        if [ "${{ steps.retry-pip-cache.outcome }}" = "success" ]; then
+          echo "cache-hit=${{ steps.retry-pip-cache.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
+          echo "cache-primary-key=${{ steps.retry-pip-cache.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "cache-hit=${{ steps.restore-pip-cache.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
+          echo "cache-primary-key=${{ steps.restore-pip-cache.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Register the job-end cache save from actions/cache without re-downloading.
+    - name: Register pip cache save
+      uses: actions/cache@v5
+      continue-on-error: true
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
+      with:
+        lookup-only: true
+        path: ${{ steps.create-directory.outputs.dir }}
+        key: ${{ runner.os }}-${{ inputs.mode }}-${{ (inputs.mode == 'pip' && hashFiles('**/setup.py')) || (inputs.mode == 'poetry' && hashFiles('**/poetry.lock')) || 'unhandled_case' }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.mode }}-
+
     - name: Report cache directory contents
       shell: bash
       run: |
-        ls -la "${{ steps.create-directory.outputs.dir }}"
+        mkdir -p "${{ steps.create-directory.outputs.dir }}"
+        ls -la "${{ steps.create-directory.outputs.dir }}" || true

--- a/cache-pip/readme.md
+++ b/cache-pip/readme.md
@@ -2,6 +2,8 @@
 
 Provides caching and pip cache configuration into a runner temporary directory.
 
+Cache restore is retried once on failure and is non-fatal so install can proceed on a cold cache. Job-end cache save behavior is preserved via a lookup-only `actions/cache` step.
+
 ```yaml
 - uses: Chia-Network/actions/cache-pip@main
 ```


### PR DESCRIPTION
## Summary

- Replace the single required `actions/cache@v5` restore with `actions/cache/restore@v5` plus one retry, both using `continue-on-error: true` and `SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1`.
- If both restores fail, the action continues so consumers can run install/pytest on a cold cache instead of failing setup.
- Preserve job-end cache save behavior with a lookup-only `actions/cache@v5` step that registers the post-job save without re-downloading the archive.
- Harden the cache directory report step with `mkdir -p` and a tolerant `ls`.
- Expose `cache-hit`, `cache-primary-key`, and `dir` outputs for consumers that want explicit save control later.

## Context

Windows matrix shards in chia-blockchain-private CI can fail during cache restore after a cache hit, before install or pytest run. Because many shards restore the same Poetry cache independently, a small per-shard restore flake rate causes frequent PR-level reruns.

Example failure: https://github.com/Chia-Network/chia-blockchain-private/actions/runs/26544713456/job/78194120757?pr=472

## Test plan

- [ ] Merge actions PR and temporarily point a chia-blockchain-private test PR at `Chia-Network/actions/cache-pip@fix/cache-pip-restore-retry`.
- [ ] Confirm Windows shards still restore cache successfully on normal runs.
- [ ] Confirm a shard that hits a restore flake retries once, then continues to install/pytest instead of failing setup.
- [ ] Confirm `test-cache-pip` workflow passes on this PR (restore/save integration test matrix).
- [ ] After merge, switch consumers back to `cache-pip@main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only composite action changes; failures fall back to cold cache and do not touch application auth, data, or runtime code.
> 
> **Overview**
> Makes **cache-pip** tolerate flaky GitHub Actions cache restores instead of failing the job when download fails after a hit.
> 
> Restore now uses **`actions/cache/restore@v5`** with **`continue-on-error`**, a **1-minute segment download timeout**, and a **single retry** if the first restore fails. A small bash step forwards **`cache-hit`** and **`cache-primary-key`** from whichever restore succeeded. **Job-end save** is kept by registering **`actions/cache@v5`** with **`lookup-only: true`** so the post-job save still runs without downloading again.
> 
> The action now exposes **`cache-hit`**, **`cache-primary-key`**, and **`dir`** outputs. The cache listing step ensures the directory exists and won’t fail the step if **`ls`** errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2ad222306ec43703ff9f269a7491972117f50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->