### PR TITLE
Add note on alert-receiver Action pointing to message Action

### DIFF
--- a/alert-receiver/readme.md
+++ b/alert-receiver/readme.md
@@ -1,5 +1,7 @@
 # Alert-Manager Receiver Action
 
+NOTE: In most cases you probably want to use the `message` Action in this repository, not this one. This is an older method to send messages from GitHub Actions using a static token. The new method uses short lived GitHub Action job JWTs.
+
 Sends JSON to the alertmanager receiver, which generates alerts in Keybase.
 
 ```yaml


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Adds a **NOTE** at the top of the `alert-receiver` README directing most users to the **`message`** Action instead. It clarifies that `alert-receiver` is the older GitHub Actions integration (static bearer token) versus the newer approach with short-lived job JWTs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9571d41df6fc05880921a5621b89baf69222af8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->