### PR TITLE
Remove python 3.9 / Fix python action related tests

### DIFF
--- a/.github/workflows/test-activate-venv.yml
+++ b/.github/workflows/test-activate-venv.yml
@@ -51,7 +51,6 @@ jobs:
               intel:
                 github: [ubuntu-latest]
             container:
-              "py3.9": docker://python:3.9-bullseye
               "py3.10": docker://python:3.10-bullseye
               "py3.11": docker://python:3.11-bullseye
               "py3.12": docker://python:3.12-bullseye
@@ -64,10 +63,6 @@ jobs:
               intel:
                 github: [windows-latest]
         python:
-          - name: "3.9"
-            action: "3.9"
-            check: "3.9"
-            matrix: "py3.9"
           - name: "3.10"
             action: "3.10"
             check: "3.10"

--- a/.github/workflows/test-poetry.yml
+++ b/.github/workflows/test-poetry.yml
@@ -24,7 +24,7 @@ jobs:
     name: ${{ matrix.os.name }} ${{ matrix.arch.name }} ${{ matrix.environment.name }} ${{ matrix.python.name }}
     runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix][matrix.environment.matrix] }}
     container: ${{ matrix.os.container[matrix.python.matrix] }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-poetry.yml
+++ b/.github/workflows/test-poetry.yml
@@ -56,7 +56,6 @@ jobs:
               intel:
                 github: [ubuntu-latest]
             container:
-              "py3.9": docker://python:3.9-bullseye
               "py3.10": docker://python:3.10-bullseye
               "py3.11": docker://python:3.11-bullseye
               "py3.12": docker://python:3.12-bullseye
@@ -69,10 +68,6 @@ jobs:
               intel:
                 github: [windows-latest]
         python:
-          - name: "3.9"
-            action: "3.9"
-            check: "3.9"
-            matrix: "py3.9"
           - name: "3.10"
             action: "3.10"
             check: "3.10"

--- a/.github/workflows/test-setup-python.yml
+++ b/.github/workflows/test-setup-python.yml
@@ -24,7 +24,7 @@ jobs:
     name: ${{ matrix.os.name }} ${{ matrix.arch.name }} ${{ matrix.environment.name }} ${{ matrix.python.name }}
     runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix][matrix.environment.matrix] }}
     container: ${{ matrix.os.container }}
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-setup-python.yml
+++ b/.github/workflows/test-setup-python.yml
@@ -24,7 +24,7 @@ jobs:
     name: ${{ matrix.os.name }} ${{ matrix.arch.name }} ${{ matrix.environment.name }} ${{ matrix.python.name }}
     runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix][matrix.environment.matrix] }}
     container: ${{ matrix.os.container }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/poetry/action.yml
+++ b/poetry/action.yml
@@ -42,7 +42,7 @@ runs:
         else
           poetry_version_string="==${{ inputs.poetry-version }}"
         fi
-        ${{ inputs.python-executable }} -m pip install -I poetry${poetry_version_string}
+        ${{ inputs.python-executable }} -m pip install --upgrade poetry${poetry_version_string}
 
     - name: Run Poetry command (Linux)
       shell: bash

--- a/setup-python/action.yml
+++ b/setup-python/action.yml
@@ -100,27 +100,17 @@ runs:
         export PYENV_ROOT="$HOME/.pyenv"
         echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
 
-        if [ ! -d "$PYENV_ROOT" ]; then
-          echo "  ====  installing pyenv at: $PYENV_ROOT"
-          curl https://pyenv.run | bash
-        else
-          echo "  ====  pyenv directory found at: $PYENV_ROOT"
-        fi
-
         export PATH="$PYENV_ROOT/bin:$PATH"
         echo "$PYENV_ROOT/bin" >> $GITHUB_PATH
         echo "PATH=$PYENV_ROOT/bin:$PATH" >> $GITHUB_ENV
 
-        # Ensure pyenv is up to date
         if ! (pyenv -h > /dev/null 2> /dev/null); then
-          echo "  ====  pyenv -h exited with non-zero status"
-          type pyenv || true
-          echo "  ====  listing: $PYENV_ROOT" || true
-          ls -l "$PYENV_ROOT" || true
-          echo "  ====  listing: $PYENV_ROOT/bin" || true
-          ls -l "$PYENV_ROOT/bin" || true
-          exit 1
+          echo "  ====  pyenv not functional, installing at: $PYENV_ROOT"
+          curl https://pyenv.run | bash
+        else
+          echo "  ====  pyenv found, updating"
         fi
+
         cd "$(pyenv root)" && git pull
 
         FULL_PY_VERSION=$(pyenv install --list | grep "^  ${{ inputs.python-version }}" | grep -v 'dev' | grep -v 't$' | tail -n 1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI matrix and composite-action install/bootstrap tweaks only; no production runtime or security-sensitive logic changes.
> 
> **Overview**
> **Drops Python 3.9** from the `test-activate-venv` and `test-poetry` workflow matrices, including the Debian Docker `python:3.9-bullseye` container entry, so CI starts at **3.10**.
> 
> **Raises job timeouts** to **20 minutes** on `test-poetry` and `test-setup-python` (from 10 and 5) to reduce flaky failures on slower matrix legs.
> 
> In **`poetry/action.yml`**, Poetry install switches from `pip install -I` to **`pip install --upgrade`**, avoiding a forced reinstall while still refreshing the package.
> 
> In **`setup-python/action.yml`**, the ARM64 **pyenv** path no longer installs pyenv up front or hard-fails with directory listings when `pyenv -h` breaks. It installs pyenv only when the CLI is missing, otherwise logs an update and always **`git pull`**s the pyenv repo before installing the requested Python.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit babf3a9f31f30fd1e6f7d685ff35672159b1dd4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->