### PR TITLE
Remove trailing slash in receiver URL input

### DIFF
--- a/message/action.yml
+++ b/message/action.yml
@@ -4,7 +4,7 @@ inputs:
   receiver_url:
     description: "Base URL of the alert-receiver worker"
     required: false
-    default: "https://alert-receiver.chiaops.com/"
+    default: "https://alert-receiver.chiaops.com"
   receiver_route:
     description: "The route to call on the receiver (appended to receiver_url)"
     required: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single default-string change in a GitHub composite action; no auth or runtime logic changes.
> 
> **Overview**
> Updates the default **`receiver_url`** in `message/action.yml` from `https://alert-receiver.chiaops.com/` to `https://alert-receiver.chiaops.com`.
> 
> This matches how the action already builds requests (`BASE_URL="${RECEIVER_URL%/}"` plus route joining), so the default no longer relies on stripping a trailing slash at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85fe8ad0d2aceab5d4e771d16e75e884ed656d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->